### PR TITLE
use tox-lsr 2.2.0

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,7 +4,7 @@ on:  # yamllint disable-line rule:truthy
   - pull_request
   - push
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@main"
+  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.2.0"
   LSR_ANSIBLES: 'ansible==2.8.* ansible==2.9.*'
   LSR_MSCENARIOS: default
   # LSR_EXTRA_PACKAGES: libdbus-1-dev

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -3,7 +3,7 @@
 dependency:
   name: galaxy
 driver:
-   name: ${LSR_MOLECULE_DRIVER:-docker}
+  name: ${LSR_MOLECULE_DRIVER:-docker}
 platforms:
   - name: centos-6
     image: registry.centos.org/centos:6

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -3,9 +3,7 @@
 dependency:
   name: galaxy
 driver:
-  name: docker
-lint:
-  enabled: false
+   name: ${LSR_MOLECULE_DRIVER:-docker}
 platforms:
   - name: centos-6
     image: registry.centos.org/centos:6
@@ -28,8 +26,6 @@ platforms:
 provisioner:
   name: ansible
   log: true
-  lint:
-    enabled: false
   playbooks:
     converge: ../../tests/tests_default.yml
 scenario:


### PR DESCRIPTION
Upgrade to tox-lsr 2.2.0 to pick up fix for improving collection
testing to get rid of black.