### PR TITLE
Print the time that task in the CI tests last

### DIFF
--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+callback_whitelist = profile_tasks


### PR DESCRIPTION
The CI tests take 5h total because each test downloads the mssql packages again each time.