### PR TITLE
Install openssl on the control node

### DIFF
--- a/tests/tests_tls.yml
+++ b/tests/tests_tls.yml
@@ -7,6 +7,12 @@
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_2019_standard_eula: true
   tasks:
+    - name: Ensure the openssl package on localhost
+      package:
+        name: openssl
+        state: present
+      delegate_to: localhost
+
     - name: >-
         Generate a self-signed certificate and public key in the test directory
         on localhost


### PR DESCRIPTION
The role uses openssl to generate TLS certificate and key.
Previously, OpenSSL was a dependency of pcs. That is no longer the case
since pcs-0.10.8-2.
Hence, the tls tests fail on Fedora because openssl is missing.