### PR TITLE
Move PowerShell install to a separate test

### DIFF
--- a/tests/tests_powershell.yml
+++ b/tests/tests_powershell.yml
@@ -1,24 +1,19 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Ensure that the role is idempotent
+- name: Ensure that the role install powershell in an idempotent manner
   hosts: all
   vars:
     mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_2019_standard_eula: true
   tasks:
-    - name: Run on a fresh host and set all parameters
+    - name: Run on a fresh host and install powershell
       include_role:
         name: linux-system-roles.mssql
       vars:
         mssql_password: "p@55w0rD"
         mssql_edition: Evaluation
-        mssql_tcp_port: 1443
-        mssql_ip_address: 0.0.0.0
-        mssql_enable_sql_agent: true
-        mssql_install_fts: true
-        mssql_enable_ha: true
-        mssql_tune_for_fua_storage: true
+        mssql_install_powershell: true
 
     - name: Configure the mssql-server service start limit interval and burst
       include_tasks: tasks/mssql-sever-increase-start-limit.yml
@@ -32,24 +27,14 @@
       vars:
         mssql_password: "p@55w0rD"
         mssql_edition: Evaluation
-        mssql_tcp_port: 1443
-        mssql_ip_address: 0.0.0.0
-        mssql_enable_sql_agent: true
-        mssql_install_fts: true
-        mssql_enable_ha: true
-        mssql_tune_for_fua_storage: true
+        mssql_install_powershell: true
 
     - name: Verify settings
       include_tasks: tasks/verify_settings.yml
       vars:
         __verify_mssql_password: "p@55w0rD"
         __verify_mssql_edition: Evaluation
-        __verify_mssql_tcp_port: 1443
-        __verify_mssql_ip_address: 0.0.0.0
-        __verify_mssql_agent_is_enabled: true
-        __verify_mssql_fts_is_installed: true
-        __verify_mssql_ha_is_installed: true
-        __verify_mssql_is_tuned_for_fua: true
+        __verify_mssql_powershell_is_installed: true
 
     - name: Run to edit settings
       include_role:
@@ -57,12 +42,7 @@
       vars:
         mssql_password: "p@55w0rd"
         mssql_edition: Standard
-        mssql_tcp_port: 1442
-        mssql_ip_address: 127.0.0.1
-        mssql_enable_sql_agent: false
-        mssql_install_fts: false
-        mssql_enable_ha: false
-        mssql_tune_for_fua_storage: false
+        mssql_install_powershell: false
 
     - name: Flush handlers
       meta: flush_handlers
@@ -73,21 +53,11 @@
       vars:
         mssql_password: "p@55w0rd"
         mssql_edition: Standard
-        mssql_tcp_port: 1442
-        mssql_ip_address: 127.0.0.1
-        mssql_enable_sql_agent: false
-        mssql_install_fts: false
-        mssql_enable_ha: false
-        mssql_tune_for_fua_storage: false
+        mssql_install_powershell: false
 
     - name: Verify disabled settings
       include_tasks: tasks/verify_settings.yml
       vars:
         __verify_mssql_password: "p@55w0rd"
         __verify_mssql_edition: Standard
-        __verify_mssql_tcp_port: 1442
-        __verify_mssql_ip_address: 127.0.0.1
-        __verify_mssql_agent_is_enabled: false
-        __verify_mssql_fts_is_installed: false
-        __verify_mssql_ha_is_installed: false
-        __verify_mssql_is_tuned_for_fua: false
+        __verify_mssql_powershell_is_installed: false


### PR DESCRIPTION
Fedora VMs do not have enough disk space to install Powershell on top of
the packages installed in the tests_idempotency playbook, hence moving
the install to a separate test for now. Later, when we will use BaseOS
CI, we will be able to increase the disk size of Fedora VMs.