### PR TITLE
Calculate tests time when using dnf proxy

### DIFF
--- a/tests/tests_accept_eula_2019.yml
+++ b/tests/tests_accept_eula_2019.yml
@@ -7,6 +7,11 @@
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
   tasks:
+    - name: Print time at the beginning of the test
+      command: date +"%Y-%m-%d %H:%M:%S"
+      register: __time1
+      changed_when: false
+
     - name: Verify the failure on a fresh host when required vars undefined
       block:
         - name: Run the role with default parameters
@@ -23,3 +28,12 @@
             that: >-
               'You must define the following variables to set up MSSQL' in
               ansible_failed_result.msg.0
+
+    - name: Print time at the end of the test
+      command: date +"%Y-%m-%d %H:%M:%S"
+      register: __time2
+      changed_when: false
+
+    - name: Print resulting time
+      debug:
+        msg: The test took {{ __time2.stdout | to_datetime - __time1.stdout | to_datetime }}

--- a/tests/tests_default_2019.yml
+++ b/tests/tests_default_2019.yml
@@ -3,6 +3,11 @@
 - name: Ensure that the role runs with default parameters
   hosts: all
   tasks:
+    - name: Print time at the beginning of the test
+      command: date +"%Y-%m-%d %H:%M:%S"
+      register: __time1
+      changed_when: false
+
     - name: Verify that by default the role fails with EULA not accepted
       block:
         - name: Run the role with default parameters
@@ -18,3 +23,12 @@
           assert:
             that: >-
               'You must accept EULA' in ansible_failed_result.msg.0
+
+    - name: Print time at the end of the test
+      command: date +"%Y-%m-%d %H:%M:%S"
+      register: __time2
+      changed_when: false
+
+    - name: Print resulting time
+      debug:
+        msg: The test took {{ __time2.stdout | to_datetime - __time1.stdout | to_datetime }}

--- a/tests/tests_idempotency_2017.yml
+++ b/tests/tests_idempotency_2017.yml
@@ -7,6 +7,11 @@
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
   tasks:
+    - name: Print time at the beginning of the test
+      command: date +"%Y-%m-%d %H:%M:%S"
+      register: __time1
+      changed_when: false
+
     - name: Run on a fresh host and set all parameters
       include_role:
         name: linux-system-roles.mssql
@@ -93,3 +98,12 @@
         __verify_mssql_fts_is_installed: false
         __verify_mssql_ha_is_installed: false
         __verify_mssql_is_tuned_for_fua: false
+
+    - name: Print time at the end of the test
+      command: date +"%Y-%m-%d %H:%M:%S"
+      register: __time2
+      changed_when: false
+
+    - name: Print resulting time
+      debug:
+        msg: The test took {{ __time2.stdout | to_datetime - __time1.stdout | to_datetime }}

--- a/tests/tests_idempotency_2019.yml
+++ b/tests/tests_idempotency_2019.yml
@@ -7,6 +7,11 @@
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
   tasks:
+    - name: Print time at the beginning of the test
+      command: date +"%Y-%m-%d %H:%M:%S"
+      register: __time1
+      changed_when: false
+
     - name: Run on a fresh host and set all parameters
       include_role:
         name: linux-system-roles.mssql
@@ -91,3 +96,12 @@
         __verify_mssql_fts_is_installed: false
         __verify_mssql_ha_is_installed: false
         __verify_mssql_is_tuned_for_fua: false
+
+    - name: Print time at the end of the test
+      command: date +"%Y-%m-%d %H:%M:%S"
+      register: __time2
+      changed_when: false
+
+    - name: Print resulting time
+      debug:
+        msg: The test took {{ __time2.stdout | to_datetime - __time1.stdout | to_datetime }}

--- a/tests/tests_include_vars_from_parent_2019.yml
+++ b/tests/tests_include_vars_from_parent_2019.yml
@@ -1,5 +1,10 @@
 - hosts: all
   tasks:
+    - name: Print time at the beginning of the test
+      command: date +"%Y-%m-%d %H:%M:%S"
+      register: __time1
+      changed_when: false
+
     - name: create var file in caller that can override the one in called role
       delegate_to: localhost
       copy:
@@ -45,3 +50,12 @@
         mssql_accept_microsoft_sql_server_standard_eula: true
         mssql_password: P@55w0rD
         mssql_edition: Evaluation
+
+    - name: Print time at the end of the test
+      command: date +"%Y-%m-%d %H:%M:%S"
+      register: __time2
+      changed_when: false
+
+    - name: Print resulting time
+      debug:
+        msg: The test took {{ __time2.stdout | to_datetime - __time1.stdout | to_datetime }}

--- a/tests/tests_input_sql_file_2019.yml
+++ b/tests/tests_input_sql_file_2019.yml
@@ -7,6 +7,11 @@
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
   tasks:
+    - name: Print time at the beginning of the test
+      command: date +"%Y-%m-%d %H:%M:%S"
+      register: __time1
+      changed_when: false
+
     - name: Set up MSSQL and input the sql file
       include_role:
         name: linux-system-roles.mssql
@@ -33,3 +38,12 @@
             that: >-
               'You must define the mssql_password variable' in
               ansible_failed_result.msg
+
+    - name: Print time at the end of the test
+      command: date +"%Y-%m-%d %H:%M:%S"
+      register: __time2
+      changed_when: false
+
+    - name: Print resulting time
+      debug:
+        msg: The test took {{ __time2.stdout | to_datetime - __time1.stdout | to_datetime }}

--- a/tests/tests_password_2017.yml
+++ b/tests/tests_password_2017.yml
@@ -7,6 +7,11 @@
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
   tasks:
+    - name: Print time at the beginning of the test
+      command: date +"%Y-%m-%d %H:%M:%S"
+      register: __time1
+      changed_when: false
+
     - name: Set up MSSQL
       include_role:
         name: linux-system-roles.mssql
@@ -86,3 +91,12 @@
       include_tasks: tasks/verify_settings.yml
       vars:
         __verify_mssql_password: "p@55w0rD11"
+
+    - name: Print time at the end of the test
+      command: date +"%Y-%m-%d %H:%M:%S"
+      register: __time2
+      changed_when: false
+
+    - name: Print resulting time
+      debug:
+        msg: The test took {{ __time2.stdout | to_datetime - __time1.stdout | to_datetime }}

--- a/tests/tests_password_2019.yml
+++ b/tests/tests_password_2019.yml
@@ -7,6 +7,11 @@
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
   tasks:
+    - name: Print time at the beginning of the test
+      command: date +"%Y-%m-%d %H:%M:%S"
+      register: __time1
+      changed_when: false
+
     - name: Set up MSSQL
       include_role:
         name: linux-system-roles.mssql
@@ -85,3 +90,12 @@
       include_tasks: tasks/verify_settings.yml
       vars:
         __verify_mssql_password: "p@55w0rD11"
+
+    - name: Print time at the end of the test
+      command: date +"%Y-%m-%d %H:%M:%S"
+      register: __time2
+      changed_when: false
+
+    - name: Print resulting time
+      debug:
+        msg: The test took {{ __time2.stdout | to_datetime - __time1.stdout | to_datetime }}

--- a/tests/tests_powershell_2019.yml
+++ b/tests/tests_powershell_2019.yml
@@ -7,6 +7,11 @@
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
   tasks:
+    - name: Print time at the beginning of the test
+      command: date +"%Y-%m-%d %H:%M:%S"
+      register: __time1
+      changed_when: false
+
     - name: Run on a fresh host and install powershell
       include_role:
         name: linux-system-roles.mssql
@@ -61,3 +66,12 @@
         __verify_mssql_password: "p@55w0rd"
         __verify_mssql_edition: Standard
         __verify_mssql_powershell_is_installed: false
+
+    - name: Print time at the end of the test
+      command: date +"%Y-%m-%d %H:%M:%S"
+      register: __time2
+      changed_when: false
+
+    - name: Print resulting time
+      debug:
+        msg: The test took {{ __time2.stdout | to_datetime - __time1.stdout | to_datetime }}

--- a/tests/tests_tls_2019.yml
+++ b/tests/tests_tls_2019.yml
@@ -7,6 +7,11 @@
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
   tasks:
+    - name: Print time at the beginning of the test
+      command: date +"%Y-%m-%d %H:%M:%S"
+      register: __time1
+      changed_when: false
+
     - name: List installed RPMs on localhost to see if openssl is present
       package_facts:
       changed_when: no
@@ -79,3 +84,12 @@
       vars:
         __verify_mssql_password: "p@55w0rD"
         __verify_mssql_is_tls_encrypted: false
+
+    - name: Print time at the end of the test
+      command: date +"%Y-%m-%d %H:%M:%S"
+      register: __time2
+      changed_when: false
+
+    - name: Print resulting time
+      debug:
+        msg: The test took {{ __time2.stdout | to_datetime - __time1.stdout | to_datetime }}

--- a/tests/tests_upgrade_2017.yml
+++ b/tests/tests_upgrade_2017.yml
@@ -7,6 +7,11 @@
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
   tasks:
+    - name: Print time at the beginning of the test
+      command: date +"%Y-%m-%d %H:%M:%S"
+      register: __time1
+      changed_when: false
+
     - name: Verify the failure when mssql_version is provided incorrectly
       block:
         - name: Run the role with incorrect mssql_version
@@ -88,3 +93,12 @@
             that: >-
               'set mssql_version to 2017, but your SQL Server is version 2019.'
               in ansible_failed_result.msg.0
+
+    - name: Print time at the end of the test
+      command: date +"%Y-%m-%d %H:%M:%S"
+      register: __time2
+      changed_when: false
+
+    - name: Print resulting time
+      debug:
+        msg: The test took {{ __time2.stdout | to_datetime - __time1.stdout | to_datetime }}


### PR DESCRIPTION
sed -i 's/^  tasks:/  tasks:\n    - name: Print time at the beginning of the test\n      command: date +"%Y-%m-%d %H:%M:%S"\n      register: __time1\n      changed_when: false\n/g' tests_*.yml
sed -i '$ a \\n    - name: Print time at the end of the test\n      command: date +"%Y-%m-%d %H:%M:%S"\n      register: __time2\n      changed_when: false\n\n    - name: Print resulting time\n      debug:\n        msg: The test took {{ __time2.stdout | to_datetime - __time1.stdout | to_datetime }}' tests_*.yml