### PR TITLE
Move inserting ansible_managed header at the end of the tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -160,14 +160,6 @@
       when: not __mssql_is_setup
       register: __mssql_conf_setup
 
-- name: Ensure ansible_managed header in configuration file
-  vars:
-    __lsr_ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"
-  blockinfile:
-    path: /var/opt/mssql/mssql.conf
-    block: "{{ __lsr_ansible_managed }}"
-    insertbefore: BOF
-
 - name: Ensure that the tuned-profiles-mssql package is installed
   package:
     name: tuned-profiles-mssql
@@ -482,3 +474,11 @@
       vars:
         __mssql_conf_setting: "network forceencryption"
         __mssql_conf_setting_value: "{{ '1' if mssql_tls_enable else 'unset' }}"
+
+- name: Ensure the ansible_managed header in /var/opt/mssql/mssql.conf
+  vars:
+    __lsr_ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"
+  blockinfile:
+    path: /var/opt/mssql/mssql.conf
+    block: "{{ __lsr_ansible_managed }}"
+    insertbefore: BOF

--- a/tests/tasks/check_header.yml
+++ b/tests/tasks/check_header.yml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Grep the ansible_managed header in /var/opt/mssql/mssql.conf
+  command: grep "^# Ansible managed" /var/opt/mssql/mssql.conf
+  changed_when: false

--- a/tests/tests_accept_eula_2019.yml
+++ b/tests/tests_accept_eula_2019.yml
@@ -23,3 +23,6 @@
             that: >-
               'You must define the following variables to set up MSSQL' in
               ansible_failed_result.msg.0
+
+    - name: Check the ansible_managed header in the configuration file
+      include_tasks: tasks/check_header.yml

--- a/tests/tests_default_2019.yml
+++ b/tests/tests_default_2019.yml
@@ -18,3 +18,6 @@
           assert:
             that: >-
               'You must accept EULA' in ansible_failed_result.msg.0
+
+    - name: Check the ansible_managed header in the configuration file
+      include_tasks: tasks/check_header.yml

--- a/tests/tests_idempotency_2017.yml
+++ b/tests/tests_idempotency_2017.yml
@@ -93,3 +93,6 @@
         __verify_mssql_fts_is_installed: false
         __verify_mssql_ha_is_installed: false
         __verify_mssql_is_tuned_for_fua: false
+
+    - name: Check the ansible_managed header in the configuration file
+      include_tasks: tasks/check_header.yml

--- a/tests/tests_idempotency_2019.yml
+++ b/tests/tests_idempotency_2019.yml
@@ -91,3 +91,6 @@
         __verify_mssql_fts_is_installed: false
         __verify_mssql_ha_is_installed: false
         __verify_mssql_is_tuned_for_fua: false
+
+    - name: Check the ansible_managed header in the configuration file
+      include_tasks: tasks/check_header.yml

--- a/tests/tests_input_sql_file_2019.yml
+++ b/tests/tests_input_sql_file_2019.yml
@@ -33,3 +33,6 @@
             that: >-
               'You must define the mssql_password variable' in
               ansible_failed_result.msg
+
+    - name: Check the ansible_managed header in the configuration file
+      include_tasks: tasks/check_header.yml

--- a/tests/tests_password_2017.yml
+++ b/tests/tests_password_2017.yml
@@ -86,3 +86,6 @@
       include_tasks: tasks/verify_settings.yml
       vars:
         __verify_mssql_password: "p@55w0rD11"
+
+    - name: Check the ansible_managed header in the configuration file
+      include_tasks: tasks/check_header.yml

--- a/tests/tests_password_2019.yml
+++ b/tests/tests_password_2019.yml
@@ -85,3 +85,6 @@
       include_tasks: tasks/verify_settings.yml
       vars:
         __verify_mssql_password: "p@55w0rD11"
+
+    - name: Check the ansible_managed header in the configuration file
+      include_tasks: tasks/check_header.yml

--- a/tests/tests_powershell_2019.yml
+++ b/tests/tests_powershell_2019.yml
@@ -61,3 +61,6 @@
         __verify_mssql_password: "p@55w0rd"
         __verify_mssql_edition: Standard
         __verify_mssql_powershell_is_installed: false
+
+    - name: Check the ansible_managed header in the configuration file
+      include_tasks: tasks/check_header.yml

--- a/tests/tests_tls_2019.yml
+++ b/tests/tests_tls_2019.yml
@@ -79,3 +79,6 @@
       vars:
         __verify_mssql_password: "p@55w0rD"
         __verify_mssql_is_tls_encrypted: false
+
+    - name: Check the ansible_managed header in the configuration file
+      include_tasks: tasks/check_header.yml

--- a/tests/tests_upgrade_2017.yml
+++ b/tests/tests_upgrade_2017.yml
@@ -88,3 +88,6 @@
             that: >-
               'set mssql_version to 2017, but your SQL Server is version 2019.'
               in ansible_failed_result.msg.0
+
+    - name: Check the ansible_managed header in the configuration file
+      include_tasks: tasks/check_header.yml


### PR DESCRIPTION
Some sqlcmd commands remove the header from config. E.g.
/opt/mssql/bin/mssql-conf set sqlagent.enabled "True"
Inserting the header must be executed at the end of the role
https://bugzilla.redhat.com/show_bug.cgi?id=2057651