### PR TITLE
support gather_facts: false; support setup-snapshot.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,19 +1,7 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Set platform/version specific variables
-  include_vars: "{{ __mssql_vars_file }}"
-  loop:
-    - "{{ ansible_facts['os_family'] }}.yml"
-    - "{{ ansible_facts['distribution'] }}.yml"
-    - >-
-      {{ ansible_facts['distribution'] ~ '_' ~
-      ansible_facts['distribution_major_version'] }}.yml
-    - >-
-      {{ ansible_facts['distribution'] ~ '_' ~
-      ansible_facts['distribution_version'] }}.yml
-  vars:
-    __mssql_vars_file: "{{ role_path }}/vars/{{ item }}"
-  when: __mssql_vars_file is file
+- name: Ensure ansible_facts and variables used by role
+  include_tasks: tasks/set_vars.yml
 
 - name: Link the deprecated accept_microsoft_sql_server_2019_standard_eula fact
   set_fact:

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Ensure ansible_facts used by role
+  setup:
+    gather_subset: min
+  when:
+    - __mssql_required_facts is defined
+    - not ansible_facts.keys() | list |
+      intersect(__mssql_required_facts) == __mssql_required_facts
+
+- name: Set platform/version specific variables
+  include_vars: "{{ __mssql_vars_file }}"
+  loop:
+    - "{{ ansible_os_family }}.yml"
+    - "{{ ansible_distribution }}.yml"
+    - "{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml"
+    - "{{ ansible_distribution }}_{{ ansible_distribution_version }}.yml"
+  vars:
+    __mssql_vars_file: "{{ role_path }}/vars/{{ item }}"
+  when: __mssql_vars_file is file

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,2 +1,0 @@
-[defaults]
-callback_whitelist = profile_tasks

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -14,10 +14,10 @@
     - name: Install test packages for version 2017 to cache then remove
       vars:
         __mssql_packages: "{{
-          __mssql_server_packages +
-          __mssql_client_packages +
-          __mssql_server_fts_packages +
-          __mssql_server_ha_packages +
+          __mssql_server_packages ~ ', ' ~
+          __mssql_client_packages | join(', ') ~ ', ' ~
+          __mssql_server_fts_packages ~ ', ' ~
+          __mssql_server_ha_packages ~ ', ' ~
           __mssql_powershell_packages
         }}"
         mssql_version: "{{ item }}"

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -1,0 +1,27 @@
+- hosts: all
+  tasks:
+    - name: Set facts used by role
+      include_role:
+        name: linux-system-roles.mssql
+        tasks_from: set_vars.yml
+        public: true
+
+    - name: Deploy the GPG key for Microsoft repositories
+      rpm_key:
+        key: "{{ mssql_rpm_key }}"
+        state: present
+
+    - name: Install test packages for version 2017 to cache then remove
+      vars:
+        __mssql_packages: "{{
+          __mssql_server_packages +
+          __mssql_client_packages +
+          __mssql_server_fts_packages +
+          __mssql_server_ha_packages +
+          __mssql_powershell_packages
+        }}"
+        mssql_version: "{{ item }}"
+      include_tasks: tasks/snapshot_install_packages.yml
+      loop:
+        - 2017
+        - 2019

--- a/tests/tasks/snapshot_install_packages.yml
+++ b/tests/tasks/snapshot_install_packages.yml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
 ---
 - name: Configure the Microsoft SQL Server {{ mssql_version }} repository
-  vars:
   yum_repository:
     name: packages-microsoft-com-mssql-server-{{ mssql_version | int }}
     description: Microsoft SQL Server {{ mssql_version }}
@@ -21,7 +20,6 @@
     state: absent
 
 - name: Remove the Microsoft SQL Server {{ mssql_version }} repository
-  vars:
   yum_repository:
     name: packages-microsoft-com-mssql-server-{{ mssql_version | int }}
     state: absent

--- a/tests/tasks/snapshot_install_packages.yml
+++ b/tests/tasks/snapshot_install_packages.yml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Configure the Microsoft SQL Server {{ mssql_version }} repository
+  vars:
+  yum_repository:
+    name: packages-microsoft-com-mssql-server-{{ mssql_version | int }}
+    description: Microsoft SQL Server {{ mssql_version }}
+    baseurl: "{{ mssql_server_repository }}"
+    gpgcheck: true
+
+- name: Install required packages
+  package:
+    name: "{{ __mssql_packages }}"
+    state: present
+
+# NOTE: Removed packages will still be in the local package cache
+# and when installed will be installed from the local disk
+- name: Remove mssql packages to keep them in cache only
+  package:
+    name: "{{ __mssql_packages }}"
+    state: absent
+
+- name: Remove the Microsoft SQL Server {{ mssql_version }} repository
+  vars:
+  yum_repository:
+    name: packages-microsoft-com-mssql-server-{{ mssql_version | int }}
+    state: absent

--- a/tests/tests_accept_eula_2019.yml
+++ b/tests/tests_accept_eula_2019.yml
@@ -23,6 +23,3 @@
             that: >-
               'You must define the following variables to set up MSSQL' in
               ansible_failed_result.msg.0
-
-    - name: Check the ansible_managed header in the configuration file
-      include_tasks: tasks/check_header.yml

--- a/tests/tests_default_2019.yml
+++ b/tests/tests_default_2019.yml
@@ -18,6 +18,3 @@
           assert:
             that: >-
               'You must accept EULA' in ansible_failed_result.msg.0
-
-    - name: Check the ansible_managed header in the configuration file
-      include_tasks: tasks/check_header.yml

--- a/tests/tests_idempotency_2017.yml
+++ b/tests/tests_idempotency_2017.yml
@@ -2,6 +2,7 @@
 ---
 - name: Ensure that the role is idempotent
   hosts: all
+  gather_facts: false
   vars:
     mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true

--- a/tests/tests_idempotency_2019.yml
+++ b/tests/tests_idempotency_2019.yml
@@ -2,6 +2,7 @@
 ---
 - name: Ensure that the role is idempotent
   hosts: all
+  gather_facts: false
   vars:
     mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true

--- a/tests/tests_input_sql_file_2019.yml
+++ b/tests/tests_input_sql_file_2019.yml
@@ -33,6 +33,3 @@
             that: >-
               'You must define the mssql_password variable' in
               ansible_failed_result.msg
-
-    - name: Check the ansible_managed header in the configuration file
-      include_tasks: tasks/check_header.yml

--- a/tests/tests_powershell_2019.yml
+++ b/tests/tests_powershell_2019.yml
@@ -61,6 +61,3 @@
         __verify_mssql_password: "p@55w0rd"
         __verify_mssql_edition: Standard
         __verify_mssql_powershell_is_installed: false
-
-    - name: Check the ansible_managed header in the configuration file
-      include_tasks: tasks/check_header.yml

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,3 +5,9 @@ __mssql_client_packages: [mssql-tools, unixODBC-devel]
 __mssql_server_fts_packages: mssql-server-fts
 __mssql_server_ha_packages: mssql-server-ha
 __mssql_powershell_packages: powershell
+__mssql_required_facts:
+  - distribution
+  - distribution_major_version
+  - distribution_version
+  - os_family
+

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,4 +10,3 @@ __mssql_required_facts:
   - distribution_major_version
   - distribution_version
   - os_family
-


### PR DESCRIPTION
Some users use gather_facts: false in their playbooks. This changes
the role to work in that case, by gathering only the facts it requires
to run.
CI testing can be sped up by creating a snapshot image pre-installed
with packages. tests/setup-snapshot.yml can be used by a CI system
to do this.