### PR TITLE
Add mssql_tls_remote_src

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,21 @@ Path to the private key file to copy to SQL Server.
 Default: `null`
 Type: `str`
 
+### 'mssql_tls_remote_src'
+
+Influence whether files provided with `mssql_tls_cert` and
+`mssql_tls_private_key` need to be transferred or already are present remotely.
+
+If `false`, the role searches for `mssql_tls_cert` and `mssql_tls_private_key`
+files on the controller node.
+
+If `true`, the role searches for `mssql_tls_cert` and `mssql_tls_private_key`
+on managed nodes.
+
+Default: `false`
+
+Type: `bool`
+
 ### `mssql_tls_version`
 
 TLS version to use.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,7 @@ mssql_tls_cert: null
 mssql_tls_private_key: null
 mssql_tls_force: false
 mssql_tls_version: 1.2
+mssql_tls_remote_src: false
 mssql_rpm_key: https://packages.microsoft.com/keys/microsoft.asc
 mssql_server_repository: "{{ __mssql_server_repository }}"
 mssql_client_repository: "{{ __mssql_client_repository }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -420,6 +420,7 @@
     - name: Copy certificate and private_key files to the host
       copy:
         src: "{{ item }}"
+        remote_src: "{{ mssql_tls_remote_src }}"
         dest: >-
           /etc/pki/tls/{{ 'certs' if item == mssql_tls_cert
           else 'private' }}/{{ item | basename }}

--- a/tests/tasks/check_header.yml
+++ b/tests/tasks/check_header.yml
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: MIT
 ---
+# Find two words in ansible_managed and grep for them in the config file
 - name: Grep the ansible_managed header in /var/opt/mssql/mssql.conf
-  command: grep "^# Ansible managed" /var/opt/mssql/mssql.conf
+  command: >-
+    grep
+    {{ lookup('template', 'get_ansible_managed.j2') |
+    regex_search('(\b\w+\s){2}') | quote }}
+    /var/opt/mssql/mssql.conf
   changed_when: false

--- a/tests/templates/get_ansible_managed.j2
+++ b/tests/templates/get_ansible_managed.j2
@@ -1,0 +1,1 @@
+{{ ansible_managed | comment }}

--- a/tests/tests_tls_2019.yml
+++ b/tests/tests_tls_2019.yml
@@ -6,11 +6,15 @@
     mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
+    mssql_password: "p@55w0rD"
+    mssql_edition: Evaluation
+    mssql_tcp_port: 1433
   tasks:
     - name: List installed RPMs on localhost to see if openssl is present
       package_facts:
       changed_when: no
       delegate_to: localhost
+      no_log: true
 
     - name: Ensure the openssl package on localhost
       package:
@@ -19,41 +23,53 @@
       delegate_to: localhost
       when: "'openssl' not in ansible_facts.packages"
 
+    - name: Create a tempfile for a certificate on hosts
+      tempfile:
+        state: file
+      register: __mssql_cert_tempfile
+
+    - name: Create a tempfile for a private key on hosts
+      tempfile:
+        state: file
+      register: __mssql_pvk_tempfile
+
     - name: >-
         Generate a self-signed certificate and public key in the test directory
         on localhost
       command: >-
         openssl req -x509 -nodes -newkey rsa:2048
         -subj "/CN={{ ansible_default_ipv4.address }}"
-        -keyout mssql.key -out mssql.pem -days 365
+        -out {{ __mssql_cert_tempfile.path }}
+        -keyout {{ __mssql_pvk_tempfile.path }} -days 365
       changed_when: true
       delegate_to: localhost
+      run_once: true
 
-    - name: >-
-        Set up MSSQL and remove the certificate and public key on localhost.
-        Test relative and full path with cert and private_key vars.
+    # Test relative and full path with mssql_tls_remote_src: false
+    - name: Copy a private key to the playbook directory to test a relative path
+      copy:
+        src: "{{ __mssql_pvk_tempfile.path }}"
+        dest: "{{ __mssql_pvk_tempfile.path | basename }}"
+      delegate_to: localhost
+      run_once: true
+
+    - name: Test relative and full path with certs on control node
       block:
-        - name: Set up MSSQL
+        - name: Run role
           include_role:
             name: linux-system-roles.mssql
             public: true
           vars:
-            mssql_password: "p@55w0rD"
-            mssql_edition: Evaluation
             mssql_tls_enable: true
-            mssql_tls_cert: "{{ playbook_dir }}/mssql.pem"
-            mssql_tls_private_key: mssql.key
-            mssql_tcp_port: 1433
-
+            mssql_tls_cert: "{{ __mssql_cert_tempfile.path }}"
+            mssql_tls_private_key: "{{ __mssql_pvk_tempfile.path | basename }}"
       always:
-        - name: Remove the certificate and public key on localhost
+        - name: Remove a private key from the playbook directory
           file:
-            path: "{{ item }}"
+            path: "{{ __mssql_pvk_tempfile.path | basename }}"
             state: absent
           delegate_to: localhost
-          loop:
-            - mssql.pem
-            - mssql.key
+          run_once: true
 
     - name: Flush handlers
       meta: flush_handlers
@@ -64,6 +80,7 @@
         __verify_mssql_password: "p@55w0rD"
         __verify_mssql_is_tls_encrypted: true
 
+    # Test disabling TLS encryption
     - name: Disable TLS encryption
       include_role:
         name: linux-system-roles.mssql
@@ -79,6 +96,43 @@
       vars:
         __verify_mssql_password: "p@55w0rD"
         __verify_mssql_is_tls_encrypted: false
+
+    # Test mssql_tls_remote_src: true
+    - name: Remove certificates from hosts
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /etc/pki/tls/certs/{{ __mssql_cert_tempfile.path | basename }}
+        - /etc/pki/tls/private/{{ __mssql_pvk_tempfile.path | basename }}
+
+    - name: Copy certificates to hosts
+      copy:
+        src: "{{ item }}"
+        dest: "{{ item }}"
+        mode: preserve
+      loop:
+        - "{{ __mssql_cert_tempfile.path }}"
+        - "{{ __mssql_pvk_tempfile.path }}"
+
+    - name: Test with certs on managed nodes
+      include_role:
+        name: linux-system-roles.mssql
+        public: true
+      vars:
+        mssql_tls_enable: true
+        mssql_tls_cert: "{{ __mssql_cert_tempfile.path }}"
+        mssql_tls_private_key: "{{ __mssql_pvk_tempfile.path }}"
+        mssql_tls_remote_src: true
+
+    - name: Flush handlers
+      meta: flush_handlers
+
+    - name: Verify connectivity and settings
+      include_tasks: tasks/verify_settings.yml
+      vars:
+        __verify_mssql_password: "p@55w0rD"
+        __verify_mssql_is_tls_encrypted: true
 
     - name: Check the ansible_managed header in the configuration file
       include_tasks: tasks/check_header.yml


### PR DESCRIPTION
SQL Server role should be able to use TLS cert and key files that are
already on managed nodes