### PR TITLE
Replace simple `mssql_input_sql_file` with `pre` and `post` variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,6 @@ If you do not pass these variables, the role only configures the SQL Server and 
 
 Note that this task is not idempotent, the role always inputs an SQL file if any of these variables is defined.
 
-When any of these variables is defined, `mssql_debug` is set to true to print the output of the `sqlcmd` command.
-
 You can find an example of an SQL file at `tests/sql_script.sql` at the role's directory.
 
 Default: `null`
@@ -166,9 +164,9 @@ Type: `str`
 ### `mssql_debug`
 
 Whether or not to print the output of sqlcmd commands.
-The role inputs SQL scripts with the sqlcmd command to configure SQL Server for HA or to input users' SQL scripts when you define `mssql_pre_input_sql_file` or `mssql_post_input_sql_file` variable.
+The role inputs SQL scripts with the sqlcmd command to configure SQL Server for HA or to input users' SQL scripts when you define a `mssql_pre_input_sql_file` or `mssql_post_input_sql_file` variable.
 
-Default: `true` if `mssql_pre_input_sql_file` or `mssql_post_input_sql_file` is defined else `false`
+Default: `false`
 
 Type: `bool`
 

--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ Type: `str`
 ### `mssql_debug`
 
 Whether or not to print the output of sqlcmd commands.
-The role inputs SQL scripts with the sqlcmd command to configure SQL Server for HA or to input users' SQL scripts when the `mssql_input_sql_file` variable is provided.
+The role inputs SQL scripts with the sqlcmd command to configure SQL Server for HA or to input users' SQL scripts when you define `mssql_pre_input_sql_file` or `mssql_post_input_sql_file` variable.
 
-Default: `true` if `mssql_input_sql_file` is defined else `false`
+Default: `true` if `mssql_pre_input_sql_file` or `mssql_post_input_sql_file` is defined else `false`
 
 Type: `bool`
 
@@ -554,7 +554,8 @@ This example shows how to use the role to set up SQL Server and enable the follo
     mssql_install_fts: true
     mssql_install_powershell: true
     mssql_tune_for_fua_storage: true
-    mssql_input_sql_file: mydatabase.sql
+    mssql_pre_input_sql_file: myusers.sql
+    mssql_post_input_sql_file: mydatabases.sql
   roles:
     - microsoft.sql.server
 ```

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ Default: `null`
 
 Type: `str`
 
+### `mssql_input_sql_file`
+
+This variable is deprecated. Use the below variables instead.
+
 ### `mssql_pre_input_sql_file` and `mssql_post_input_sql_file`
 
 You can use the role to input a file containing SQL statements or procedures into SQL Server.
@@ -153,7 +157,7 @@ Note that this task is not idempotent, the role always inputs an SQL file if any
 
 When any of these variables is defined, `mssql_debug` is set to true to print the output of the `sqlcmd` command.
 
-You can find an example of an SQL file at `tests/sql_script.sql`.
+You can find an example of an SQL file at `tests/sql_script.sql` at the role's directory.
 
 Default: `null`
 

--- a/README.md
+++ b/README.md
@@ -136,21 +136,24 @@ Default: `null`
 
 Type: `str`
 
-### `mssql_input_sql_file`
+### `mssql_pre_input_sql_file` and `mssql_post_input_sql_file`
 
 You can use the role to input a file containing SQL statements or procedures into SQL Server.
-With this variable, enter the path to the SQL file containing the database configuration.
 
-When specifying this variable, you must also specify the `mssql_password`
-variable because authentication is required to input an SQL file to SQL Server.
+* Use `mssql_pre_input_sql_file` to input the SQL file immediately after the role configures SQL Server.
+* Use `mssql_post_input_sql_file` to input the SQL file at the end of the role invocation.
 
-If you do not pass this variable, the role only configures the SQL Server and does not input any SQL file.
+With these variables, enter the path to the files containing SQL scripts.
 
-Note that this task is not idempotent, the role always inputs an SQL file if this variable is defined.
+When specifying any of these variables, you must also specify the `mssql_password` variable because authentication is required to input an SQL file to SQL Server.
 
-When this variable is defined, `mssql_debug` is set to true to print the output of the `sqlcmd` command.
+If you do not pass these variables, the role only configures the SQL Server and does not input any SQL file.
 
-You can find an example of the SQL file at `tests/sql_script.sql`.
+Note that this task is not idempotent, the role always inputs an SQL file if any of these variables is defined.
+
+When any of these variables is defined, `mssql_debug` is set to true to print the output of the `sqlcmd` command.
+
+You can find an example of an SQL file at `tests/sql_script.sql`.
 
 Default: `null`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,8 +10,14 @@ mssql_edition: null
 mssql_tcp_port: 1433
 mssql_firewall_configure: false
 mssql_ip_address: null
-mssql_input_sql_file: null
-mssql_debug: "{{ true if mssql_input_sql_file is not none else false }}"
+mssql_pre_input_sql_file: null
+mssql_post_input_sql_file: null
+mssql_debug: "{{
+  true if (mssql_input_sql_file is not none) or
+  (mssql_pre_input_sql_file is not none) or
+  (mssql_post_input_sql_file is not none)
+  else false
+}}"
 mssql_enable_sql_agent: null
 mssql_install_fts: null
 mssql_install_powershell: null

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,12 +12,7 @@ mssql_firewall_configure: false
 mssql_ip_address: null
 mssql_pre_input_sql_file: null
 mssql_post_input_sql_file: null
-mssql_debug: "{{
-  true if (mssql_input_sql_file is not none) or
-  (mssql_pre_input_sql_file is not none) or
-  (mssql_post_input_sql_file is not none)
-  else false
-}}"
+mssql_debug: false
 mssql_enable_sql_agent: null
 mssql_install_fts: null
 mssql_install_powershell: null

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,15 +14,36 @@
     __mssql_sqlcmd_login_cmd: null
 
 - name: Link the deprecated accept_microsoft_sql_server_2019_standard_eula fact
-  set_fact:
-    mssql_accept_microsoft_sql_server_standard_eula: >-
-      {{ mssql_accept_microsoft_sql_server_2019_standard_eula }}
   when: mssql_accept_microsoft_sql_server_2019_standard_eula is defined
+  block:
+    - name: Print that the variable is deprecated
+      debug:
+        msg: >-
+          "The accept_microsoft_sql_server_2019_standard_eula variable is
+          deprecated and will be removed in a future version. Edit your playbook
+          to use the mssql_accept_microsoft_sql_server_standard_eula variable
+          instead."
+
+    - name: >-
+        Link the deprecated accept_microsoft_sql_server_2019_standard_eula fact
+      set_fact:
+        mssql_accept_microsoft_sql_server_standard_eula: >-
+          {{ mssql_accept_microsoft_sql_server_2019_standard_eula }}
 
 - name: Link the deprecated mssql_input_sql_file fact
-  set_fact:
-    mssql_input_sql_file: "{{ mssql_input_sql_file }}"
   when: mssql_input_sql_file is defined
+  block:
+    - name: Print that the mssql_input_sql_file variable is deprecated
+      debug:
+        msg: >-
+          "The mssql_input_sql_file variable is deprecated and will be removed
+          in a future version. Edit your playbook to use
+          mssql_post_input_sql_file and mssql_pre_input_sql_file variables
+          instead."
+
+    - name: Link the deprecated mssql_input_sql_file fact
+      set_fact:
+        mssql_post_input_sql_file: "{{ mssql_input_sql_file }}"
 
 - name: Verify that the user accepts EULA variables
   assert:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,11 @@
       {{ mssql_accept_microsoft_sql_server_2019_standard_eula }}
   when: mssql_accept_microsoft_sql_server_2019_standard_eula is defined
 
+- name: Link the deprecated mssql_input_sql_file fact
+  set_fact:
+    mssql_input_sql_file: "{{ mssql_input_sql_file }}"
+  when: mssql_input_sql_file is defined
+
 - name: Verify that the user accepts EULA variables
   assert:
     that:
@@ -286,6 +291,17 @@
         - MSSQL_SA_PASSWORD: "{{ mssql_password }}"
       when: __mssql_password_query is failed
       notify: Restart the mssql-server service
+
+# Keep this task after setting password
+- name: Input the {{ mssql_pre_input_sql_file }} sql file to SQL Server
+  vars:
+    __mssql_input_sql_file: "{{ mssql_pre_input_sql_file }}"
+  include_tasks: input_sql_file.yml
+  when: mssql_pre_input_sql_file is not none
+
+- name: Unset the mssql_pre_input_sql_file fact
+  set_fact:
+    mssql_pre_input_sql_file: null
 
 - name: Set a new edition for MSSQL
   when:
@@ -783,10 +799,12 @@
     insertbefore: BOF
 
 # Keep this task at the bottom, it must be run at the end of the role
-- name: Input the {{ mssql_input_sql_file }} sql file to SQL Server
+- name: Input the {{ mssql_post_input_sql_file }} sql file to SQL Server
   vars:
-    __mssql_input_sql_file: "{{ mssql_input_sql_file }}"
+    __mssql_input_sql_file: "{{ mssql_post_input_sql_file }}"
   include_tasks: input_sql_file.yml
-  when:
-    - mssql_input_sql_file is defined
-    - mssql_input_sql_file is not none
+  when: mssql_post_input_sql_file is not none
+
+- name: Unset the mssql_post_input_sql_file fact
+  set_fact:
+    mssql_post_input_sql_file: null

--- a/tests/sql_script.sql
+++ b/tests/sql_script.sql
@@ -1,11 +1,67 @@
-CREATE LOGIN MyLogin WITH PASSWORD = 'p@55w0rD'
-CREATE USER MyUser FOR LOGIN MyLogin
-CREATE DATABASE ExampleDB
+IF NOT EXISTS (
+  SELECT name
+  FROM master.sys.server_principals
+  WHERE name = 'MyLogin'
+)
+BEGIN
+  PRINT 'Creating the MyLogin login';
+  CREATE LOGIN MyLogin WITH PASSWORD = 'p@55w0rD'
+  PRINT 'The MyLogin login created successfully';
+END
+ELSE
+BEGIN
+  PRINT 'The MyLogin login already exists, skipping';
+END
+
+IF NOT EXISTS (
+  SELECT name
+  FROM sys.database_principals
+  WHERE name = 'MyUser')
+BEGIN
+  PRINT 'Creating the MyUser user';
+  CREATE USER MyUser FOR LOGIN MyLogin
+  PRINT 'The MyUser user created successfully';
+END
+ELSE
+BEGIN
+  PRINT 'The MyUser user already exists, skipping';
+END
+
+IF NOT EXISTS(
+  SELECT name
+  FROM sys.databases
+  WHERE name = 'ExampleDB'
+)
+BEGIN
+  PRINT 'Creating the ExampleDB database';
+  CREATE DATABASE ExampleDB;
+  PRINT 'The ExampleDB database created successfully';
+END
+ELSE
+BEGIN
+  PRINT 'The ExampleDB database already exists, skipping';
+END
 GO
-USE ExampleDB
-CREATE TABLE Inventory (id INT, name NVARCHAR(50), quantity INT)
-INSERT INTO Inventory VALUES (1, 'apple', 100)
-INSERT INTO Inventory VALUES (2, 'orange', 150)
-INSERT INTO Inventory VALUES (3, 'banana', 154)
-INSERT INTO Inventory VALUES (4, N'バナナ', 170)
+
+USE ExampleDB;
+GO
+
+IF NOT EXISTS (
+  SELECT name, xtype
+  FROM sysobjects
+  WHERE name='Inventory' and xtype='U'
+)
+BEGIN
+  PRINT 'Adding the Inventory table to the ExampleDB database';
+  CREATE TABLE Inventory (id INT, name NVARCHAR(50), quantity INT);
+  INSERT INTO Inventory VALUES (1, 'apple', 100);
+  INSERT INTO Inventory VALUES (2, 'orange', 150);
+  INSERT INTO Inventory VALUES (3, 'banana', 154);
+  INSERT INTO Inventory VALUES (4, N'バナナ', 170);
+  PRINT 'The Inventory table created successfully';
+END
+ELSE
+BEGIN
+  PRINT 'The Inventory table already exists, skipping';
+END
 GO

--- a/tests/tests_configure_ha_cluster.yml
+++ b/tests/tests_configure_ha_cluster.yml
@@ -48,11 +48,9 @@
         name: fedora.linux_system_roles.ha_cluster
         tasks_from: test_setup.yml
 
-    - name: Configure SQL Server and create an ExampleDB database on primary
-      vars:
-        mssql_input_sql_file: create_example_db.j2
-      include_role:
-        name: linux-system-roles.mssql
+    - name: Set the mssql_pre_input_sql_file fact to appear on primary
+      set_fact:
+        mssql_pre_input_sql_file: create_example_db.j2
       when: mssql_ha_replica_type == 'primary'
 
     - name: Run on all hosts to configure HA cluster

--- a/tests/tests_input_sql_file_2019.yml
+++ b/tests/tests_input_sql_file_2019.yml
@@ -7,11 +7,12 @@
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
   tasks:
-    - name: Set up MSSQL and input the sql file
+    - name: Set up MSSQL and input sql files
       include_role:
         name: linux-system-roles.mssql
       vars:
-        mssql_input_sql_file: sql_script.sql
+        mssql_pre_input_sql_file: sql_script.sql
+        mssql_post_input_sql_file: sql_script.sql
         mssql_password: "p@55w0rD"
         mssql_edition: Evaluation
 
@@ -21,7 +22,26 @@
           include_role:
             name: linux-system-roles.mssql
           vars:
-            mssql_input_sql_file: sql_script.sql
+            mssql_pre_input_sql_file: sql_script.sql
+
+        - name: Unreachable task
+          fail:
+            msg: The above task must fail
+
+      rescue:
+        - name: Assert that the role failed with mssql_password not defined
+          assert:
+            that: >-
+              'You must define the mssql_password variable' in
+              ansible_failed_result.msg
+
+    - name: Verify the failure when the mssql_password var is not specified
+      block:
+        - name: Input the sql file without the mssql_password variable
+          include_role:
+            name: linux-system-roles.mssql
+          vars:
+            mssql_post_input_sql_file: sql_script.sql
 
         - name: Unreachable task
           fail:

--- a/tests/tests_input_sql_file_2019.yml
+++ b/tests/tests_input_sql_file_2019.yml
@@ -16,6 +16,22 @@
         mssql_password: "p@55w0rD"
         mssql_edition: Evaluation
 
+    - name: Assert the latest script invocation resulted in no changes
+      assert:
+        that:
+          - >-
+            'The MyLogin login already exists, skipping' in
+            __mssql_sqlcmd_input_file.stdout
+          - >-
+            'The MyUser user already exists, skipping' in
+            __mssql_sqlcmd_input_file.stdout
+          - >-
+            'The ExampleDB database already exists, skipping' in
+            __mssql_sqlcmd_input_file.stdout
+          - >-
+            'The Inventory table already exists, skipping' in
+            __mssql_sqlcmd_input_file.stdout
+
     - name: Verify the failure when the mssql_password var is not specified
       block:
         - name: Input the sql file without the mssql_password variable


### PR DESCRIPTION
Previously, `mssql_input_sql_file` input SQL files at the end of the
role invocation. However, users must input some SQL files at the
beginning of the role before it applies any configuration to SQL Server.
`mssql_pre_input_sql_file` and `mssql_post_input_sql_file` has been
added to address this functionality.