### PR TITLE
Do not publish legacy role format to galaxy, mssql only has a collection

### DIFF
--- a/.github/workflows/changelog_to_tag.yml
+++ b/.github/workflows/changelog_to_tag.yml
@@ -74,8 +74,3 @@ jobs:
           body_path: ./.tagmsg.txt
           draft: false
           prerelease: false
-      - name: Publish role to Galaxy
-        uses: robertdebock/galaxy-action@1.2.0
-        with:
-          galaxy_api_key: ${{ secrets.galaxy_api_key }}
-          git_branch: ${{ steps.tag.outputs.branch }}


### PR DESCRIPTION
Removing Github Action that publishes a collection in a legacy role format to Galaxy. mssql only publishes microsoft.sql collection to Galaxy, so this is not applicable.