### PR TITLE
Remove the workaround for `any_errors_fatal: true`

### DIFF
--- a/tasks/input_sql_file.yml
+++ b/tasks/input_sql_file.yml
@@ -84,9 +84,9 @@
         - not mssql_debug
       changed_when: false
 
-    # This is required because in the case when a task that precedes the input
-    # task fails, the print task prints a previous result
-    - name: Unset the __mssql_sqlcmd_input_file variable
-      set_fact:
-        __mssql_sqlcmd_input_file: ""
-      when: not mssql_debug
+    # This is required because the always block resets the failed tasks status
+    # and causes the any_error_fatal: true setting to count tasks as not failed
+    - name: Fail because the Input with sqlcmd task failed
+      fail:
+        msg: Fail because the Input with sqlcmd task failed
+      when: __mssql_sqlcmd_input_file is failed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -558,6 +558,7 @@
         __mssql_ha_seeding_mode: "{{ __mssql_ha_seeding_mode }}"
 
 - name: Configure availability group on the primary node
+  any_errors_fatal: true
   when:
     - mssql_ha_configure | bool
     - mssql_ha_replica_type == 'primary'
@@ -657,42 +658,11 @@
         __mssql_input_sql_file: replicate_db.j2
       include_tasks: input_sql_file.yml
 
-    # This is required because `any_errors_fatal: true` does not work within
-    # blocks that have rescue or always sections
-    - name: Set a fact to indicate successful set up on the primary replica
-      delegate_to: localhost
-      set_fact:
-        __mssql_primary_successful: true
-      run_once: true
-  rescue:
-    # changed_when: false because this task removes unused remnant of cert files
-    - name: Remove certificate and private key from the control node
-      delegate_to: localhost
-      file:
-        path: "{{ item }}"
-        state: absent
-      loop:
-        - cert
-        - key
-      changed_when: false
-
-    - name: Fail because this rescue block does not actually rescue failed tasks
-      fail:
-        msg: Configuration tasks failed
-
 - name: Configure availability group on replicas
   when:
     - mssql_ha_configure | bool
     - mssql_ha_replica_type in ['synchronous', 'witness']
-  any_errors_fatal: true
   block:
-    - name: Fail if the primary node failed
-      delegate_to: localhost
-      fail:
-        msg: "Halting playbook execution due to error on the primary node"
-      when: not __mssql_primary_successful | d(false)
-      run_once: true
-
     - name: Ensure the {{ __mssql_server_ha_packages }} package
       package:
         name: "{{ __mssql_server_ha_packages }}"


### PR DESCRIPTION
Previously, the role would use a workaround of setting a
__mssql_primary_successful variable to define whether the primary node
really failed or not. This was required because any_errors_fatal: true
would not work when run in a block where rescue or always block would
execute.
This workaround creates troubles when the order of hosts in inventory is
not primary-secondary-witness - the role skips a rescue block after
failing tasks in the block on primary and goes to the next block.
Removing the workardound for stability. Certificate and private key now
won't be removed from the control node in the case of failure, but those
files will be removed on a next successful role invocation.