### PR TITLE
Remove mssql_ha_firewall_configure, rename mssql_firewall_configure to mssql_manage_firewall

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,19 +104,24 @@ Type: `str`
 
 The port that SQL Server listens on.
 
+If you set `mssql_firewall_configure` to `false`, you must open the firewall port defined with the `mssql_tcp_port` variable prior to running this role.
+
+You can change the TCP port by setting this variable to a different port.
+If you set `mssql_firewall_configure` to `true` while changing the TCP port, the role closes the previously opened firewall port.
+
 Default: `1433`
 
 Type: `int`
 
 ### `mssql_firewall_configure`
 
-Whether to open the `mssql_tcp_port` port in the Linux firewall.
+Whether to open firewall ports required by this role.
 
 When this variable is set to `true`, the role enables firewall even if it was not enabled.
 
 The role uses the `fedora.linux_system_roles.firewall` role to manage the firewall, hence, only firewall implementations supported by the `fedora.linux_system_roles.firewall` role work.
 
-If you set this variable to `false`, you must open the port defined with the `mssql_tcp_port` variable prior to running this role.
+If you set this variable to `false`, you must open required ports prior to running this role.
 
 Default: `false`
 
@@ -375,26 +380,14 @@ Default: no default
 
 Type: `str`
 
-#### `mssql_ha_firewall_configure`
-
-Whether to open ports in the Linux firewall for an Always On availability group.
-
-When this variable is set to `true`, the role enables firewall even if it was not enabled.
-
-The role uses the `fedora.linux_system_roles.firewall` role to manage the firewall, hence, only firewall implementations supported by the `fedora.linux_system_roles.firewall` role work.
-
-If you set this variable to `false`, you must open the port defined with the `mssql_ha_listener_port` variable prior to running this role.
-
-Default: `false`
-
-Type: `bool`
-
 #### `mssql_ha_listener_port`
 
 The TCP port used to replicate data for an Always On availability group.
 
 Note that due to an SQL Server limitation it is not possible to change a listener port number on an existing availability group when the availability group contains a configuration-only replica.
 To do that, you must re-create the availability group using the required port number.
+
+If you set `mssql_firewall_configure` to `false`, you must open the firewall port defined with the `mssql_ha_listener_port` variable prior to running this role.
 
 Default: `5022`
 
@@ -679,7 +672,6 @@ Note that production environments require Pacemaker configured with fencing agen
     mssql_edition: Evaluation
     mssql_firewall_configure: true
     mssql_ha_configure: true
-    mssql_ha_firewall_configure: true
     mssql_ha_listener_port: 5022
     mssql_ha_cert_name: ExampleCert
     mssql_ha_master_key_password: "p@55w0rD1"
@@ -717,7 +709,6 @@ For more information, see the `fedora.linux_system_roles.ha_cluster` role docume
     mssql_edition: Evaluation
     mssql_firewall_configure: true
     mssql_ha_configure: true
-    mssql_ha_firewall_configure: true
     mssql_ha_listener_port: 5022
     mssql_ha_cert_name: ExampleCert
     mssql_ha_master_key_password: "p@55w0rD1"
@@ -811,7 +802,6 @@ Note that production environments require Pacemaker configured with fencing agen
     mssql_edition: Evaluation
     mssql_firewall_configure: true
     mssql_ha_configure: true
-    mssql_ha_firewall_configure: true
     mssql_ha_listener_port: 5022
     mssql_ha_cert_name: ExampleCert
     mssql_ha_master_key_password: "p@55w0rD1"
@@ -923,7 +913,6 @@ This example playbooks sets the `firewall` variables for the `fedora.linux_syste
     mssql_password: "p@55w0rD"
     mssql_edition: Evaluation
     mssql_ha_configure: true
-    mssql_ha_firewall_configure: true
     mssql_ha_listener_port: 5022
     mssql_ha_cert_name: ExampleCert
     mssql_ha_master_key_password: "p@55w0rD1"

--- a/README.md
+++ b/README.md
@@ -104,16 +104,16 @@ Type: `str`
 
 The port that SQL Server listens on.
 
-If you set `mssql_firewall_configure` to `false`, you must open the firewall port defined with the `mssql_tcp_port` variable prior to running this role.
+If you set `mssql_manage_firewall` to `false`, you must open the firewall port defined with the `mssql_tcp_port` variable prior to running this role.
 
 You can change the TCP port by setting this variable to a different port.
-If you set `mssql_firewall_configure` to `true` while changing the TCP port, the role closes the previously opened firewall port.
+If you set `mssql_manage_firewall` to `true` while changing the TCP port, the role closes the previously opened firewall port.
 
 Default: `1433`
 
 Type: `int`
 
-### `mssql_firewall_configure`
+### `mssql_manage_firewall`
 
 Whether to open firewall ports required by this role.
 
@@ -387,7 +387,7 @@ The TCP port used to replicate data for an Always On availability group.
 Note that due to an SQL Server limitation it is not possible to change a listener port number on an existing availability group when the availability group contains a configuration-only replica.
 To do that, you must re-create the availability group using the required port number.
 
-If you set `mssql_firewall_configure` to `false`, you must open the firewall port defined with the `mssql_ha_listener_port` variable prior to running this role.
+If you set `mssql_manage_firewall` to `false`, you must open the firewall port defined with the `mssql_ha_listener_port` variable prior to running this role.
 
 Default: `5022`
 
@@ -556,7 +556,7 @@ This example shows how to use the role to set up SQL Server, configure it with a
     mssql_edition: Evaluation
     mssql_tcp_port: 1433
     mssql_ip_address: 0.0.0.0
-    mssql_firewall_configure: true
+    mssql_manage_firewall: true
   roles:
     - microsoft.sql.server
 ```
@@ -579,7 +579,7 @@ This example shows how to use the role to set up SQL Server and enable the follo
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_password: "p@55w0rD"
     mssql_edition: Evaluation
-    mssql_firewall_configure: true
+    mssql_manage_firewall: true
     mssql_enable_sql_agent: true
     mssql_install_fts: true
     mssql_install_powershell: true
@@ -602,7 +602,7 @@ This example shows how to use the role to set up SQL Server and configure it to 
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_password: "p@55w0rD"
     mssql_edition: Evaluation
-    mssql_firewall_configure: true
+    mssql_manage_firewall: true
     mssql_tls_enable: true
     mssql_tls_cert: mycert.pem
     mssql_tls_private_key: mykey.key
@@ -670,7 +670,7 @@ Note that production environments require Pacemaker configured with fencing agen
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_password: "p@55w0rD"
     mssql_edition: Evaluation
-    mssql_firewall_configure: true
+    mssql_manage_firewall: true
     mssql_ha_configure: true
     mssql_ha_listener_port: 5022
     mssql_ha_cert_name: ExampleCert
@@ -707,7 +707,7 @@ For more information, see the `fedora.linux_system_roles.ha_cluster` role docume
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_password: "p@55w0rD"
     mssql_edition: Evaluation
-    mssql_firewall_configure: true
+    mssql_manage_firewall: true
     mssql_ha_configure: true
     mssql_ha_listener_port: 5022
     mssql_ha_cert_name: ExampleCert
@@ -800,7 +800,7 @@ Note that production environments require Pacemaker configured with fencing agen
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_password: "p@55w0rD"
     mssql_edition: Evaluation
-    mssql_firewall_configure: true
+    mssql_manage_firewall: true
     mssql_ha_configure: true
     mssql_ha_listener_port: 5022
     mssql_ha_cert_name: ExampleCert
@@ -909,7 +909,7 @@ This example playbooks sets the `firewall` variables for the `fedora.linux_syste
     mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
-    mssql_firewall_configure: true
+    mssql_manage_firewall: true
     mssql_password: "p@55w0rD"
     mssql_edition: Evaluation
     mssql_ha_configure: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ mssql_upgrade: false
 mssql_password: null
 mssql_edition: null
 mssql_tcp_port: 1433
-mssql_firewall_configure: false
+mssql_manage_firewall: false
 mssql_ip_address: null
 mssql_pre_input_sql_file: null
 mssql_post_input_sql_file: null

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,7 +31,6 @@ mssql_ha_configure: false
 # mssql_ha_replica_type must be set per host in inventory. Setting it hear to
 # avoid "variable not defined" error in Ansible
 mssql_ha_replica_type: null
-mssql_ha_firewall_configure: false
 mssql_ha_listener_port: 5022
 mssql_ha_cert_name: null
 mssql_ha_private_key_password: null

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -535,7 +535,7 @@
     - name: >-
         Open the {{ mssql_ha_listener_port }}/tcp port and
         enable the high-availability service in firewall
-      when: mssql_ha_firewall_configure | bool
+      when: mssql_firewall_configure | bool
       include_role:
         name: fedora.linux_system_roles.firewall
       vars:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -366,14 +366,14 @@
   when: mssql_ip_address is not none
 
 - name: Register the previous tcpport setting
-  when: mssql_firewall_configure | bool
+  when: mssql_manage_firewall | bool
   command: grep '^tcpport = ' {{ __mssql_conf_path }}
   failed_when: false
   changed_when: false
   register: __mssql_previous_tcp_port
 
 - name: Open the {{ mssql_tcp_port }} TCP port
-  when: mssql_firewall_configure | bool
+  when: mssql_manage_firewall | bool
   include_role:
     name: fedora.linux_system_roles.firewall
   vars:
@@ -404,7 +404,7 @@
   include_role:
     name: fedora.linux_system_roles.firewall
   when:
-    - mssql_firewall_configure | bool
+    - mssql_manage_firewall | bool
     - __tcpport | int != mssql_tcp_port | int
 
 - name: Configure the sqlagent setting
@@ -535,7 +535,7 @@
     - name: >-
         Open the {{ mssql_ha_listener_port }}/tcp port and
         enable the high-availability service in firewall
-      when: mssql_firewall_configure | bool
+      when: mssql_manage_firewall | bool
       include_role:
         name: fedora.linux_system_roles.firewall
       vars:

--- a/tests/tests_configure_ha_cluster.yml
+++ b/tests/tests_configure_ha_cluster.yml
@@ -9,7 +9,7 @@
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_password: "p@55w0rD"
     mssql_edition: Evaluation
-    mssql_firewall_configure: true
+    mssql_manage_firewall: true
     mssql_ha_configure: true
     mssql_ha_listener_port: 5022
     mssql_ha_cert_name: ExampleCert

--- a/tests/tests_configure_ha_cluster.yml
+++ b/tests/tests_configure_ha_cluster.yml
@@ -11,7 +11,6 @@
     mssql_edition: Evaluation
     mssql_firewall_configure: true
     mssql_ha_configure: true
-    mssql_ha_firewall_configure: true
     mssql_ha_listener_port: 5022
     mssql_ha_cert_name: ExampleCert
     mssql_ha_master_key_password: "p@55w0rD1"
@@ -153,7 +152,6 @@
       - ExampleDB2
     mssql_debug: true
     mssql_ha_configure: true
-    mssql_ha_firewall_configure: true
     mssql_ha_listener_port: 5022
     mssql_ha_cert_name: ExampleCert
     mssql_ha_master_key_password: "p@55w0rD1"

--- a/tests/tests_tcp_firewall.yml
+++ b/tests/tests_tcp_firewall.yml
@@ -6,7 +6,7 @@
     mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
-    mssql_firewall_configure: true
+    mssql_manage_firewall: true
   tasks:
     - name: Test while not settings mssql_tcp_port to default it to 1433
       vars:


### PR DESCRIPTION
Previously, two variables existed, mssql_ha_firewall_configure and
mssql_firewall_configure. For simplicity, the role now only uses
mssql_firewall_configure for configuring firewall.

mssql_manage_firewall makes more sense because firewall is a service and
the word manage fits it better.
Other system roles use the rolename_manage_firewall wording too and
mssql must be consistent with them for simplicity
