### PR TITLE
Add mssql_ha_db_names to let users replicate multiple DBs

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,11 +328,13 @@ Use the variables starting with the `mssql_ha_` prefix to configure an SQL Serve
 **Prerequisites**
 
 * Ensure that your hosts meet the requirements for high availability configuration, namely DNS resolution configured so that hosts can communicate using short names.
-For more information, see Prerequisites in [Configure SQL Server Always On Availability Group for high availability on Linux](https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-availability-group-configure-ha?view=sql-server-ver15#prerequisites).
-* In SQL Server, create a database to be used for replication.
-Provide the database name to the role with the [`mssql_ha_db_name`](#mssql_ha_db_name) variable.
-You can set the [`mssql_pre_input_sql_file`](#mssql_pre_input_sql_file-and-mssql_post_input_sql_file) variable to pre-create the database.
-For more information, see the description of the [`mssql_ha_db_name`](#mssql_ha_db_name) variable.
+  For more information, see Prerequisites in [Configure SQL Server Always On Availability Group for high availability on Linux](https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-availability-group-configure-ha?view=sql-server-ver15#prerequisites).
+* Optional: In SQL Server, create one or more databases to be used for replication.
+  Provide databases names to the role with the [`mssql_ha_db_names`](#mssql_ha_db_names) variable.
+  You can set the [`mssql_pre_input_sql_file`](#mssql_pre_input_sql_file-and-mssql_post_input_sql_file) variable to pre-create databases.
+  For more information, see the description of the [`mssql_ha_db_names`](#mssql_ha_db_names) variable.
+
+  If you do not provide the [`mssql_ha_db_names`](#mssql_ha_db_names) variable, the role creates a cluster without replicating database in it.
 
 Configuring for high availability is not supported on RHEL 7 because the `fedora.linux_system_roles.ha_cluster` role does not support RHEL 7.
 
@@ -446,13 +448,17 @@ Default: `null`
 
 Type: `string`
 
-#### `mssql_ha_db_name`
+#### `mssql_ha_db_names`
 
-The name of the database to be replicated.
-This database must exist in SQL Server.
+This is an optional variable.
 
-You can write a T-SQL script that creates a database and feed it into the role with the [`mssql_pre_input_sql_file`](#mssql_pre_input_sql_file-and-mssql_post_input_sql_file) variable.
-This way, the role runs your script to create a database after ensuring that SQL Server is running and then replicates this database for high availability.
+You can set this variable to the list of names of one or more existing SQL databases to replicate these database in the cluster.
+The role backs up databases provided if no back up newer than 3 hours exists to the `/var/opt/mssql/data/` directory.
+
+If you do not provide this variable, the role creates a cluster without replicating databases in it.
+
+You can write a T-SQL script that creates database and feed it into the role with the [`mssql_pre_input_sql_file`](#mssql_pre_input_sql_file-and-mssql_post_input_sql_file) variable.
+This way, the role runs your script to create databases after ensuring that SQL Server is running and then replicate these databases for high availability.
 
 For example, you can write a `create_example_db.sql` SQL script that creates a test database and feed it into the SQL Server from the primary replica with `mssql_pre_input_sql_file` prior to running the role.
 
@@ -468,17 +474,6 @@ For example, you can write a `create_example_db.sql` SQL script that creates a t
 ```
 
 Default: `null`
-
-Type: `string`
-
-#### `mssql_ha_db_backup_path`
-
-For SQL Server, any database participating in an Availability Group must be in a full recovery mode and have a valid log backup.
-The role uses this path to backup the database provided with `mssql_ha_db_name` prior to initiating replication within an Always On availability group.
-
-The role backs up the database provided with `mssql_ha_db_backup_path` if no back up newer than 3 hours exists.
-
-Default: `/var/opt/mssql/data/{{ mssql_ha_db_name }}.bak`
 
 Type: `string`
 
@@ -692,7 +687,9 @@ Note that production environments require Pacemaker configured with fencing agen
     mssql_ha_reset_cert: false
     mssql_ha_endpoint_name: Example_Endpoint
     mssql_ha_ag_name: ExampleAG
-    mssql_ha_db_name: ExampleDB
+    mssql_ha_db_names:
+      - ExampleDB1
+      - ExampleDB2
     mssql_ha_login: ExamleLogin
     mssql_ha_login_password: "p@55w0rD3"
     mssql_ha_virtual_ip: 192.XXX.XXX.XXX
@@ -728,7 +725,9 @@ For more information, see the `fedora.linux_system_roles.ha_cluster` role docume
     mssql_ha_reset_cert: false
     mssql_ha_endpoint_name: Example_Endpoint
     mssql_ha_ag_name: ExampleAG
-    mssql_ha_db_name: ExampleDB
+    mssql_ha_db_names:
+      - ExampleDB1
+      - ExampleDB2
     mssql_ha_login: ExampleLogin
     mssql_ha_login_password: "p@55w0rD3"
     mssql_ha_virtual_ip: 192.XXX.XXX.XXX
@@ -820,7 +819,9 @@ Note that production environments require Pacemaker configured with fencing agen
     mssql_ha_reset_cert: false
     mssql_ha_endpoint_name: Example_Endpoint
     mssql_ha_ag_name: ExampleAG
-    mssql_ha_db_name: ExampleDB
+    mssql_ha_db_names:
+      - ExampleDB1
+      - ExampleDB2
     mssql_ha_login: ExampleLogin
     mssql_ha_login_password: "p@55w0rD3"
     mssql_ha_virtual_ip: 192.XXX.XXX.XXX
@@ -930,7 +931,9 @@ This example playbooks sets the `firewall` variables for the `fedora.linux_syste
     mssql_ha_reset_cert: false
     mssql_ha_endpoint_name: Example_Endpoint
     mssql_ha_ag_name: ExampleAG
-    mssql_ha_db_name: ExampleDB
+    mssql_ha_db_names:
+      - ExampleDB1
+      - ExampleDB2
     mssql_ha_login: ExampleLogin
     mssql_ha_login_password: "p@55w0rD3"
     # Set mssql_ha_virtual_ip to the frontend IP address configured in the Azure

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,9 @@ mssql_rpm_key: https://packages.microsoft.com/keys/microsoft.asc
 mssql_server_repository: "{{ __mssql_server_repository }}"
 mssql_client_repository: "{{ __mssql_client_repository }}"
 mssql_ha_configure: false
+# mssql_ha_replica_type must be set per host in inventory. Setting it hear to
+# avoid "variable not defined" error in Ansible
+mssql_ha_replica_type: null
 mssql_ha_firewall_configure: false
 mssql_ha_listener_port: 5022
 mssql_ha_cert_name: null

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,8 +36,7 @@ mssql_ha_master_key_password: null
 mssql_ha_reset_cert: false
 mssql_ha_endpoint_name: null
 mssql_ha_ag_name: null
-mssql_ha_db_name: null
-mssql_ha_db_backup_path: /var/opt/mssql/data/{{ mssql_ha_db_name }}.bak
+mssql_ha_db_names: null
 mssql_ha_login: null
 mssql_ha_login_password: null
 mssql_ha_virtual_ip: null

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -653,10 +653,11 @@
         __mssql_input_sql_file: grant_permissions_to_ha_login.j2
       include_tasks: input_sql_file.yml
 
-    - name: Back up and replicate the {{ mssql_ha_db_name }} database
+    - name: Back up and replicate databases
       vars:
         __mssql_input_sql_file: replicate_db.j2
       include_tasks: input_sql_file.yml
+      when: mssql_ha_db_names is not none
 
 - name: Configure availability group on replicas
   when:

--- a/templates/replicate_db.j2
+++ b/templates/replicate_db.j2
@@ -1,36 +1,38 @@
+{% for item in mssql_ha_db_names %}
+{%   set db_backup_path = "/var/opt/mssql/data/" + item %}
 IF NOT EXISTS (
   SELECT name, recovery_model_desc
   FROM sys.databases
-  WHERE name = '{{ mssql_ha_db_name }}' AND
+  WHERE name = '{{ item }}' AND
         recovery_model_desc = 'FULL'
 )
 BEGIN
-  PRINT 'Setting RECOVERY FULL on the {{ mssql_ha_db_name }} database';
-  ALTER DATABASE {{ mssql_ha_db_name }} SET RECOVERY FULL;
-  PRINT 'RECOVERY FULL on the {{ mssql_ha_db_name }} database set successfully';
+  PRINT 'Setting RECOVERY FULL on the {{ item }} database';
+  ALTER DATABASE {{ item }} SET RECOVERY FULL;
+  PRINT 'RECOVERY FULL on the {{ item }} database set successfully';
 END
 ELSE
 BEGIN
-  PRINT 'RECOVERY FULL on the {{ mssql_ha_db_name }} database is set, skipping';
+  PRINT 'RECOVERY FULL on the {{ item }} database is set, skipping';
 END
 
 IF NOT EXISTS (
   SELECT [database_name], backup_start_date, backup_finish_date, [type]
   FROM msdb.dbo.backupset
   WHERE [type]='D' AND
-        [database_name]='{{ mssql_ha_db_name }}' AND
+        [database_name]='{{ item }}' AND
         backup_finish_date >= DATEADD(hh, -3, GETDATE())
 )
 BEGIN
-  PRINT 'Backing up the {{ mssql_ha_db_name }} database to \
-{{ mssql_ha_db_backup_path }}';
-  BACKUP DATABASE {{ mssql_ha_db_name }}
-    TO DISK = N'{{ mssql_ha_db_backup_path }}';
-  PRINT 'The {{ mssql_ha_db_name }} database backed up successfully';
+  PRINT 'Backing up the {{ item }} database to \
+{{ db_backup_path }}';
+  BACKUP DATABASE {{ item }}
+    TO DISK = N'{{ db_backup_path }}';
+  PRINT 'The {{ item }} database backed up successfully';
 END
 ELSE
 BEGIN
-  PRINT 'The {{ mssql_ha_db_name }} database is already backed up, skipping';
+  PRINT 'The {{ item }} database is already backed up, skipping';
 END
 
 IF NOT EXISTS (
@@ -55,15 +57,16 @@ IF NOT EXISTS (
     AND dbcs.group_database_id = dbrs.group_database_id
 )
 BEGIN
-  PRINT 'Adding the {{ mssql_ha_db_name }} database to the \
+  PRINT 'Adding the {{ item }} database to the \
 {{ mssql_ha_ag_name }} availability group';
   ALTER AVAILABILITY GROUP {{ mssql_ha_ag_name }}
-    ADD DATABASE {{ mssql_ha_db_name }};
-  PRINT 'The {{ mssql_ha_db_name }} database added to the \
+    ADD DATABASE {{ item }};
+  PRINT 'The {{ item }} database added to the \
 {{ mssql_ha_ag_name }} availability group successfully';
 END
 ELSE
 BEGIN
-  PRINT 'The {{ mssql_ha_db_name }} database is already added to the \
+  PRINT 'The {{ item }} database is already added to the \
 {{ mssql_ha_ag_name }} availability group, skipping';
 END
+{% endfor %}

--- a/tests/tests_configure_ha_cluster.yml
+++ b/tests/tests_configure_ha_cluster.yml
@@ -19,7 +19,9 @@
     mssql_ha_reset_cert: false
     mssql_ha_endpoint_name: Example_Endpoint
     mssql_ha_ag_name: ExampleAG
-    mssql_ha_db_name: ExampleDB
+    mssql_ha_db_names:
+      - ExampleDB1
+      - ExampleDB2
     mssql_ha_login: ExampleLogin
     mssql_ha_login_password: "p@55w0rD3"
     mssql_ha_virtual_ip: 192.168.122.148
@@ -119,10 +121,14 @@
         name: fedora.linux_system_roles.ha_cluster
         tasks_from: test_setup.yml
 
-    - name: Set facts to create a test DB on primary as a pre task
-      set_fact:
-        mssql_pre_input_sql_file: create_example_db.j2
-        __mssql_test_db_name: "{{ mssql_ha_db_name }}"
+    - name: Configure SQL Server and create test databases on primary
+      vars:
+        __mssql_input_sql_file: create_example_db.j2
+        __mssql_test_db_name: "{{ item }}"
+      include_role:
+        name: linux-system-roles.mssql
+        tasks_from: input_sql_file.yml
+      loop: "{{ mssql_ha_db_names }}"
       when: mssql_ha_replica_type == 'primary'
 
     - name: Run on all hosts to configure HA cluster
@@ -142,8 +148,9 @@
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_password: "p@55w0rD"
     mssql_edition: Evaluation
-    mssql_ha_db_name: ExampleDB
-    __mssql_test_db_name: "{{ mssql_ha_db_name }}"
+    mssql_ha_db_names:
+      - ExampleDB1
+      - ExampleDB2
     mssql_debug: true
     mssql_ha_configure: true
     mssql_ha_firewall_configure: true
@@ -663,13 +670,23 @@
           assert:
             that:
               - >-
-                "RECOVERY FULL on the {{ mssql_ha_db_name }} database is set,
-                skipping" in __mssql_sqlcmd_input_file.stdout
+                "RECOVERY FULL on the ExampleDB1 database is set, skipping"
+                in __mssql_sqlcmd_input_file.stdout
               - >-
-                "The {{ mssql_ha_db_name }} database is already backed up,
-                skipping" in __mssql_sqlcmd_input_file.stdout
+                "The ExampleDB1 database is already backed up, skipping"
+                in __mssql_sqlcmd_input_file.stdout
               - >-
-                "database is already added to the {{ mssql_ha_ag_name }}
+                "The ExampleDB1 database is already added to the ExampleAG
+                availability group, skipping"
+                in __mssql_sqlcmd_input_file.stdout
+              - >-
+                "RECOVERY FULL on the ExampleDB2 database is set, skipping"
+                in __mssql_sqlcmd_input_file.stdout
+              - >-
+                "The ExampleDB2 database is already backed up, skipping"
+                in __mssql_sqlcmd_input_file.stdout
+              - >-
+                "The ExampleDB2 database is already added to the ExampleAG
                 availability group, skipping"
                 in __mssql_sqlcmd_input_file.stdout
 


### PR DESCRIPTION
- Replace mssql_ha_db_name with mssql_ha_db_names so that users can
  provide a list of databases to be replicated
- Previously, a database must exist in SQL Server to create a cluster.
  Now mssql_ha_db_names is optional, if it is not provided the role
  creates a cluster without replicating databases
- Remove mssql_ha_db_backup_path and always back up to the
  /var/opt/mssql/data/ directory for simplicity