### PR TITLE
Replicate all provided databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,9 @@ This is an optional variable.
 You can set this variable to the list of names of one or more existing SQL databases to replicate these database in the cluster.
 The role backs up databases provided if no back up newer than 3 hours exists to the `/var/opt/mssql/data/` directory.
 
-If you do not provide this variable, the role creates a cluster without replicating databases in it.
+If you do not provide this variable when configuring new SQL Server, the role creates a cluster without replicating databases in it.
+
+The role does not remove databases not listed with this variable from existing SQL Server clusters.
 
 You can write a T-SQL script that creates database and feed it into the role with the [`mssql_pre_input_sql_file`](#mssql_pre_input_sql_file-and-mssql_post_input_sql_file) variable.
 This way, the role runs your script to create databases after ensuring that SQL Server is running and then replicate these databases for high availability.

--- a/templates/replicate_db.j2
+++ b/templates/replicate_db.j2
@@ -55,6 +55,7 @@ IF NOT EXISTS (
   LEFT OUTER JOIN master.sys.dm_hadr_database_replica_states AS dbrs
     ON dbcs.replica_id = dbrs.replica_id
     AND dbcs.group_database_id = dbrs.group_database_id
+  WHERE dbcs.database_name = '{{ item }}'
 )
 BEGIN
   PRINT 'Adding the {{ item }} database to the \


### PR DESCRIPTION
This change fixes the bug where only the first database provided with
mssql_ha_db_names got replicated