### PR TITLE
DRAFT: Implement WRITE_LEASE_VALIDITY

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -634,7 +634,8 @@
         __mssql_input_sql_file: create_ha_login.j2
       include_tasks: input_sql_file.yml
 
-    # Required for configure_ag.j2 to set WRITE_LEASE_VALIDITY based on RHEL ver
+    # Required for configure_ag.j2 to set WRITE_LEASE_VALIDITY based on
+    # mssql-server version
     - name: Get mssql-server version to see if WRITE_LEASE_VALIDITY is available
       package_facts:
         manager: auto

--- a/templates/configure_ag.j2
+++ b/templates/configure_ag.j2
@@ -216,9 +216,9 @@ IF NOT EXISTS (
 BEGIN
   PRINT 'Creating the {{ mssql_ha_ag_name }} availability group';
   CREATE AVAILABILITY GROUP {{ mssql_ha_ag_name }}
-{% if ansible_os_family == 'RedHat' and
-  ansible_distribution_version is version('8.3', '<') %}
-    WITH (DB_FAILOVER = ON, CLUSTER_TYPE = EXTERNAL)
+{% if ansible_facts.packages['mssql-server'][0]['version']
+   is version('15.0.4153.1', '>=') %}
+    WITH (DB_FAILOVER = ON, CLUSTER_TYPE = EXTERNAL, WRITE_LEASE_VALIDITY=20)
 {% else %}
     WITH (DB_FAILOVER = ON, CLUSTER_TYPE = EXTERNAL)
 {% endif %}

--- a/tests/tests_configure_ha_cluster.yml
+++ b/tests/tests_configure_ha_cluster.yml
@@ -67,6 +67,8 @@
           - attrs:
               - name: notify
                 value: true
+              - name: on_fail
+                value: demote
     ha_cluster_constraints_colocation:
       - resource_leader:
           id: ag_cluster-clone


### PR DESCRIPTION
This functionality still doesn't work. Keeping the PR for history.

Fails with the following:
```
TASK [linux-system-roles.mssql : Print the output of the sqlcmd command for configure_listener.j2 if not empty] ******************************************************************************
ok: [primary] => {
    "__mssql_sqlcmd_input_file.stdout_lines": [
        "Adding the ExampleAG-listener listener to the ExampleAG availability group",
        "Msg 19407, Level 16, State 2, Server primary, Line 8",
        "The lease between availability group 'ExampleAG' and the Windows Server Failover Cluster has expired. A connectivity issue occurred between the instance of SQL Server and the Windows Server Failover Cluster. To determine whether the availability group is failing over correctly, check the corresponding availability group resource in the Windows Server Failover Cluster.",
        "Added the ExampleAG-listener listener successfully"
    ]
}
```