### PR TITLE
Remove support for Fedora 36

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   platforms:
     - name: Fedora
       versions:
-        - all
+        - 35
     - name: EL
       versions:
         - 8
@@ -17,4 +17,7 @@ galaxy_info:
     - fedora
     - centos
     - mssql
+    - sql
+    - microsoft
+    - database
 dependencies: []


### PR DESCRIPTION
mssql-server package does not support Fedora at all but it works on Fedora <36. Once Microsoft adds mssql-server package for RHEL 9 it should work on Fedora 36 too.