### PR TITLE
Add check for non-inclusive language

### DIFF
--- a/.collection/README.md
+++ b/.collection/README.md
@@ -24,7 +24,7 @@ Please see the [Using Ansible collections documentation](https://docs.ansible.co
 
 ## Documentation
 
-You can find the documentation for the microsoft.sql.server role in its repository in [README.md](https://github.com/linux-system-roles/mssql/blob/master/README.md).
+You can find the documentation for the microsoft.sql.server role in its repository in [README.md](https://github.com/linux-system-roles/mssql/blob/main/README.md).
 
 ## Supported Ansible Versions
 

--- a/.collection/galaxy.yml
+++ b/.collection/galaxy.yml
@@ -8,7 +8,7 @@ authors:
 
 repository: "https://github.com/linux-system-roles/mssql"
 # yamllint disable-line rule:line-length
-documentation: "https://github.com/linux-system-roles/mssql/blob/master/README.md"
+documentation: "https://github.com/linux-system-roles/mssql/blob/main/README.md"
 issues: "https://github.com/linux-system-roles/mssql/issues"
 
 readme: "README.md"

--- a/.github/actions/custom-woke-action/LICENSE
+++ b/.github/actions/custom-woke-action/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright © 2020 Caitlin Elfring <celfring@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/.github/actions/custom-woke-action/README.md
+++ b/.github/actions/custom-woke-action/README.md
@@ -1,0 +1,78 @@
+# woke-action
+
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/get-woke/woke-action?logo=github&sort=semver)](https://github.com/get-woke/woke-action/releases)
+
+Woke GitHub Actions allow you to execute [`woke`](https://github.com/get-woke/woke) command within GitHub Actions.
+
+The output of the actions can be viewed from the Actions tab in the main repository view.
+
+## Usage
+
+The most common usage is to run `woke` on a file/directory. This workflow can be configured by adding the following content to the GitHub Actions workflow YAML file (ie in `.github/workflows/woke.yaml`).
+
+```yaml
+name: woke
+on:
+  - pull_request
+jobs:
+  woke:
+    name: woke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: woke
+        uses: get-woke/woke-action@v0
+        with:
+          # Cause the check to fail on any broke rules
+          fail-on-error: true
+```
+
+## Inputs
+
+Inputs to configure the `woke` GitHub Actions.
+
+| Input            | Default               | Description                                                                                       |
+|------------------|-----------------------|---------------------------------------------------------------------------------------------------|
+| `woke-args`      | `.`                   | (Optional) Additional flags to run woke with (see <https://github.com/get-woke/woke#usage>) |
+| `woke-version`   | latest                | (Optional) Release version of `woke` (defaults to latest version)                                 |
+| `fail-on-error`  | `false`               | (Optional) Fail the GitHub Actions check for any failures.                                        |
+| `workdir`        | `.`                   | (Optional) Run `woke` this working directory relative to the root directory.                      |
+| `github-token`   | `${{ github.token }}` | (Optional) Custom GitHub Access token (ie `${{ secrets.MY_CUSTOM_TOKEN }}`).                      |
+
+## License
+
+This application is licensed under the MIT License, you may obtain a copy of it
+[here](https://github.com/get-woke/woke-action/blob/main/LICENSE).
+
+## Only Changed Files
+
+If you're interested in only running `woke` against files that have changed in a PR,
+consider something like [Get All Changed Files Action](https://github.com/marketplace/actions/get-all-changed-files). With this, you can add a workflow that looks like:
+
+```yaml
+
+name: 'woke'
+on:
+  - pull_request
+jobs:
+  woke:
+    name: 'woke'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+
+      - uses: jitterbit/get-changed-files@v1
+        id: files
+
+      - name: 'woke'
+        uses: get-woke/woke-action@v0
+        with:
+          # Cause the check to fail on any broke rules
+          fail-on-error: true
+          # See https://github.com/marketplace/actions/get-all-changed-files
+          # for more options
+          woke-args: ${{ steps.files.outputs.added_modified }}
+```

--- a/.github/actions/custom-woke-action/action.yml
+++ b/.github/actions/custom-woke-action/action.yml
@@ -1,0 +1,46 @@
+name: 'Run woke'
+description: >-
+  Run woke on pull requests to detect non-inclusive language
+  in your source code.
+author: 'Caitlin Elfring (caitlinelfring)'
+inputs:
+  github-token:
+    description: 'GITHUB_TOKEN'
+    required: true
+    default: ${{ github.token }}
+  woke-args:
+    description: 'woke arguments'
+    default: '.'
+    required: false
+  fail-on-error:
+    description: |
+      Exit code when errors are found [true,false]
+      Default is `false`.
+    default: 'false'
+    required: false
+  workdir:
+    description: 'Working directory relative to the root directory.'
+    default: '.'
+    required: false
+  woke-version:
+    description: >-
+      woke version, defaults to the latest `v0` version.
+      Override to pin to a specific version
+    default: 'v0'
+    required: false
+runs:
+  using: 'composite'
+  steps:
+    - run: $GITHUB_ACTION_PATH/entrypoint.sh
+      shell: bash
+      env:
+        # INPUT_<VARIABLE_NAME> is not available in Composite run steps
+        # https://github.com/actions/runner/issues/665
+        INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
+        INPUT_WOKE_VERSION: ${{ inputs.woke-version }}
+        INPUT_WOKE_ARGS: ${{ inputs.woke-args }}
+        INPUT_FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
+        INPUT_WORKDIR: ${{ inputs.workdir }}
+branding:
+  icon: 'check-circle'
+  color: 'gray-dark'

--- a/.github/actions/custom-woke-action/entrypoint.sh
+++ b/.github/actions/custom-woke-action/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# shellcheck disable=SC2086
+
+set -e
+
+cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit 1
+
+TEMP_PATH="$(mktemp -d)"
+PATH="${TEMP_PATH}:$PATH"
+
+echo '::group:: Installing woke ... https://github.com/nhosoi/woke'
+curl https://raw.githubusercontent.com/nhosoi/woke/main/woke -o "${TEMP_PATH}/woke"
+chmod 0755 "${TEMP_PATH}/woke"
+echo '::endgroup::'
+
+echo '::group:: Running woke ...'
+woke \
+  --output github-actions \
+  --exit-1-on-failure="${INPUT_FAIL_ON_ERROR:-false}" \
+  ${INPUT_WOKE_ARGS}
+echo '::endgroup::'

--- a/.github/actions/custom-woke-action/testdata/bad.txt
+++ b/.github/actions/custom-woke-action/testdata/bad.txt
@@ -1,0 +1,1 @@
+I have a whitelist and a blacklist. What should I do about it?

--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -1,0 +1,19 @@
+# yamllint disable rule:line-length
+name: Check for non-inclusive language
+on:  # yamllint disable-line rule:truthy
+  - pull_request
+jobs:
+  woke:
+    name: woke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: custom woke
+        # Originally, uses: get-woke/woke-action@v0
+        uses: ./.github/actions/custom-woke-action
+        with:
+          woke-args: "-c https://raw.githubusercontent.com/linux-system-roles/tox-lsr/main/src/tox_lsr/config_files/woke.yml --count-only-error-for-failure"
+          # Cause the check to fail on any broke rules
+          fail-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -283,9 +283,6 @@ mssql_ha_db_names got replicated
 
 - Use GITHUB_REF_NAME as name of push branch; fix error in branch detection [citest skip]
   - We need to get the name of the branch to which CHANGELOG.md was pushed.
-    For now, it looks as though `GITHUB_REF_NAME` is that name.  But don't
-    trust it - first, check that it is `main` or `master`.  If not, then use
-    a couple of other methods to determine what is the push branch.
     Signed-off-by: Rich Megginson <rmeggins@redhat.com>
 
 - tests_tls: generate certs on managed nodes to avoid installing local RPM (#82)


### PR DESCRIPTION
**Add check for non-inclusive language.**
    
Add a check for usage of terms and language that is considered
non-inclusive. We are using the woke tool for this with a wordlist
that can be found at
https://github.com/linux-system-roles/tox-lsr/blob/main/src/tox_lsr/config_files/woke.yml
    
Note: this commit uses the customized woke placed locally in .github/actions/custom-woke-action to support a new option --count-only-error-for-failure option.
The local action custom-woke-action will be replaced with the official woke once https://github.com/get-woke/woke/pull/252 (Add an option "--count-only-error-for-failure") is processed.

**Clean up non-inclusive words.** 
- .collection/README.md
- .collection/galaxy.yml
- CHANGELOG.md

Note: the changes in .collection/README.md and .collection/galaxy.yml expect the `master` branch to be renamed to `main` branch. I.e., until it happens, we want to keep this pr as a draft.