### PR TITLE
Rename mssql_ha_listener_port to mssql_ha_log_transport_port

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ Setting to `false` does not remove configuration for high availability.
 When set to `true`, the role performs the following tasks:
 
 1. Include the `fedora.linux_system_roles.firewall` role to configure firewall:
-     1. Open the firewall port set with the [`mssql_ha_listener_port`](#mssql_ha_listener_port) variable.
+     1. Open the firewall port set with the [`mssql_ha_log_transport_port`](#mssql_ha_log_transport_port) variable.
      2. Enable the `high-availability` service in firewall.
 2. Configure SQL Server for high availability:
      1. Enable AlwaysOn Health events.
@@ -579,14 +579,14 @@ Default: no default
 
 Type: `string`
 
-##### `mssql_ha_listener_port`
+##### `mssql_ha_log_transport_port`
 
 The TCP port used to replicate data for an Always On availability group.
 
 Note that due to an SQL Server limitation it is not possible to change a listener port number on an existing availability group when the availability group contains a configuration-only replica.
 To do that, you must re-create the availability group using the required port number.
 
-If you set `mssql_manage_firewall` to `false`, you must open the firewall port defined with the `mssql_ha_listener_port` variable prior to running this role.
+If you set `mssql_manage_firewall` to `false`, you must open the firewall port defined with the `mssql_ha_log_transport_port` variable prior to running this role.
 
 Default: `5022`
 
@@ -782,7 +782,7 @@ In this case the role does not configure Pacemaker.
     mssql_manage_firewall: true
     mssql_ha_configure: true
     mssql_ha_ag_cluster_type: none
-    mssql_ha_listener_port: 5022
+    mssql_ha_log_transport_port: 5022
     mssql_ha_cert_name: ExampleCert
     mssql_ha_master_key_password: "p@55w0rD1"
     mssql_ha_private_key_password: "p@55w0rD2"
@@ -819,7 +819,7 @@ For more information, see the `fedora.linux_system_roles.ha_cluster` role docume
     mssql_manage_firewall: true
     mssql_ha_configure: true
     mssql_ha_ag_cluster_type: external
-    mssql_ha_listener_port: 5022
+    mssql_ha_log_transport_port: 5022
     mssql_ha_cert_name: ExampleCert
     mssql_ha_master_key_password: "p@55w0rD1"
     mssql_ha_private_key_password: "p@55w0rD2"
@@ -914,7 +914,7 @@ Note that production environments require Pacemaker configured with fencing agen
     mssql_manage_firewall: true
     mssql_ha_configure: true
     mssql_ha_ag_cluster_type: external
-    mssql_ha_listener_port: 5022
+    mssql_ha_log_transport_port: 5022
     mssql_ha_cert_name: ExampleCert
     mssql_ha_master_key_password: "p@55w0rD1"
     mssql_ha_private_key_password: "p@55w0rD2"
@@ -1027,7 +1027,7 @@ This example playbooks sets the `firewall` variables for the `fedora.linux_syste
     mssql_edition: Evaluation
     mssql_ha_configure: true
     mssql_ha_ag_cluster_type: external
-    mssql_ha_listener_port: 5022
+    mssql_ha_log_transport_port: 5022
     mssql_ha_cert_name: ExampleCert
     mssql_ha_master_key_password: "p@55w0rD1"
     mssql_ha_private_key_password: "p@55w0rD2"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,7 +32,7 @@ mssql_ha_ag_cluster_type: external
 # mssql_ha_replica_type must be set per host in inventory. Setting it hear to
 # avoid "variable not defined" error in Ansible
 mssql_ha_replica_type: null
-mssql_ha_listener_port: 5022
+mssql_ha_endpoint_port: 5022
 mssql_ha_cert_name: null
 mssql_ha_private_key_password: null
 mssql_ha_master_key_password: null

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,23 +9,6 @@
   set_fact:
     __mssql_sqlcmd_login_cmd: null
 
-- name: Link the deprecated accept_microsoft_sql_server_2019_standard_eula fact
-  when: mssql_accept_microsoft_sql_server_2019_standard_eula is defined
-  block:
-    - name: Print that the variable is deprecated
-      debug:
-        msg: >-
-          The accept_microsoft_sql_server_2019_standard_eula variable is
-          deprecated and will be removed in a future version. Edit your playbook
-          to use the mssql_accept_microsoft_sql_server_standard_eula variable
-          instead.
-
-    - name: >-
-        Link the deprecated accept_microsoft_sql_server_2019_standard_eula fact
-      set_fact:
-        mssql_accept_microsoft_sql_server_standard_eula: >-
-          {{ mssql_accept_microsoft_sql_server_2019_standard_eula }}
-
 - name: Link the deprecated mssql_input_sql_file fact
   when: mssql_input_sql_file is defined
   block:
@@ -40,6 +23,20 @@
     - name: Link the deprecated mssql_input_sql_file fact
       set_fact:
         mssql_post_input_sql_file: "{{ mssql_input_sql_file }}"
+
+- name: Link the deprecated mssql_ha_listener_port fact
+  when: mssql_ha_listener_port is defined
+  block:
+    - name: Print that the variable is deprecated
+      debug:
+        msg: >-
+          The mssql_ha_listener_port variable is deprecated and will be removed
+          in a future version. Edit your playbook to use the
+          mssql_ha_endpoint_port variable instead.
+
+    - name: Link the deprecated mssql_ha_listener_port fact
+      set_fact:
+        mssql_ha_endpoint_port: "{{ mssql_ha_listener_port }}"
 
 - name: Verify that the user accepts EULA variables
   assert:
@@ -647,13 +644,13 @@
       block:
         - name: >-
             Open the port and enable the high-availability service in
-            firewall tcp port {{ mssql_ha_listener_port }}
+            firewall tcp port {{ mssql_ha_endpoint_port }}
           when: mssql_manage_firewall | bool
           include_role:
             name: fedora.linux_system_roles.firewall
           vars:
             firewall:
-              - port: "{{ mssql_ha_listener_port }}/tcp"
+              - port: "{{ mssql_ha_endpoint_port }}/tcp"
                 state: enabled
                 permanent: true
                 runtime: true

--- a/templates/configure_ag.j2
+++ b/templates/configure_ag.j2
@@ -94,7 +94,7 @@ removing this replica re-create it';
     ALTER AVAILABILITY GROUP {{ mssql_ha_ag_name }} ADD REPLICA ON
       N'{{ hostvars[item]['ansible_hostname'] }}' WITH (
         ENDPOINT_URL = N'tcp://{{
-          hostvars[item]['ansible_fqdn'] }}:{{ mssql_ha_listener_port }}',
+          hostvars[item]['ansible_fqdn'] }}:{{ mssql_ha_endpoint_port }}',
         AVAILABILITY_MODE = {{ hostvars[item]['__mssql_ha_availability_mode'] }},
         FAILOVER_MODE = {{ hostvars[item]['__mssql_ha_failover_mode'] }},
         SEEDING_MODE = {{ hostvars[item]['__mssql_ha_seeding_mode'] }}
@@ -102,7 +102,7 @@ removing this replica re-create it';
 {%     elif hostvars[item]['mssql_ha_replica_type'] == 'witness' %}
     ALTER AVAILABILITY GROUP {{ mssql_ha_ag_name }} ADD REPLICA ON
       N'{{ hostvars[item]['ansible_hostname'] }}' WITH (
-        ENDPOINT_URL = N'tcp://{{ hostvars[item]['ansible_fqdn'] }}:{{ mssql_ha_listener_port }}',
+        ENDPOINT_URL = N'tcp://{{ hostvars[item]['ansible_fqdn'] }}:{{ mssql_ha_endpoint_port }}',
         AVAILABILITY_MODE = {{ hostvars[item]['__mssql_ha_availability_mode'] }}
       );
 {%     endif %}
@@ -118,7 +118,7 @@ removing this replica re-create it';
   "sql_setting_name":"ENDPOINT_URL",
   "sys_setting_name":"endpoint_url",
   "setting_value":"N'tcp://" + hostvars[item]['ansible_fqdn'] + ":" +
-    mssql_ha_listener_port | string + "'"
+    mssql_ha_endpoint_port | string + "'"
 },
 "failover_mode":{
   "sql_setting_name":"FAILOVER_MODE",
@@ -142,7 +142,7 @@ removing this replica re-create it';
   "sql_setting_name":"ENDPOINT_URL",
   "sys_setting_name":"endpoint_url",
   "setting_value":"N'tcp://" + hostvars[item]['ansible_fqdn'] + ":" +
-    mssql_ha_listener_port | string + "'"
+    mssql_ha_endpoint_port | string + "'"
 }
 }) %}
 {%     endif %}
@@ -242,7 +242,7 @@ BEGIN
 {%   if hostvars[item]['mssql_ha_replica_type'] == 'primary' %}
       N'{{ hostvars[item]['ansible_hostname'] }}' WITH (
         ENDPOINT_URL = N'tcp://{{
-          hostvars[item]['ansible_fqdn'] }}:{{ mssql_ha_listener_port }}',
+          hostvars[item]['ansible_fqdn'] }}:{{ mssql_ha_endpoint_port }}',
         AVAILABILITY_MODE = {{ hostvars[item]['__mssql_ha_availability_mode'] }},
         FAILOVER_MODE = {{ hostvars[item]['__mssql_ha_failover_mode'] }},
         SEEDING_MODE = {{ hostvars[item]['__mssql_ha_seeding_mode'] }},
@@ -251,7 +251,7 @@ BEGIN
       ),
       N'{{ hostvars[item]['ansible_hostname'] }}' WITH (
         ENDPOINT_URL = N'tcp://{{
-          hostvars[item]['ansible_fqdn'] }}:{{ mssql_ha_listener_port }}',
+          hostvars[item]['ansible_fqdn'] }}:{{ mssql_ha_endpoint_port }}',
         AVAILABILITY_MODE = {{ hostvars[item]['__mssql_ha_availability_mode'] }},
         FAILOVER_MODE = {{ hostvars[item]['__mssql_ha_failover_mode'] }},
         SEEDING_MODE = {{ hostvars[item]['__mssql_ha_seeding_mode'] }},
@@ -260,7 +260,7 @@ BEGIN
       ),
       N'{{ hostvars[item]['ansible_hostname'] }}' WITH (
         ENDPOINT_URL = N'tcp://{{
-          hostvars[item]['ansible_fqdn'] }}:{{ mssql_ha_listener_port }}',
+          hostvars[item]['ansible_fqdn'] }}:{{ mssql_ha_endpoint_port }}',
         AVAILABILITY_MODE = {{ hostvars[item]['__mssql_ha_availability_mode'] }}
 {%   endif %}
 {% endfor %}

--- a/templates/configure_endpoint.j2
+++ b/templates/configure_endpoint.j2
@@ -7,7 +7,7 @@ BEGIN
   PRINT 'Endpoint {{ mssql_ha_endpoint_name }} does not exist, creating';
   CREATE ENDPOINT {{ mssql_ha_endpoint_name }}
     STATE = STARTED
-    AS TCP (LISTENER_PORT = {{ mssql_ha_listener_port }})
+    AS TCP (LISTENER_PORT = {{ mssql_ha_endpoint_port }})
     FOR DATABASE_MIRRORING (
       ROLE = {{ __mssql_ha_endpoint_role }},
       AUTHENTICATION = CERTIFICATE {{ mssql_ha_cert_name }},
@@ -21,18 +21,18 @@ BEGIN
   IF NOT EXISTS (
     SELECT name, port FROM sys.tcp_endpoints
     WHERE name = '{{ mssql_ha_endpoint_name }}' AND
-          port = {{ mssql_ha_listener_port }}
+          port = {{ mssql_ha_endpoint_port }}
   )
   BEGIN
     ALTER ENDPOINT {{ mssql_ha_endpoint_name }}
-      AS TCP (LISTENER_PORT = {{ mssql_ha_listener_port }});
+      AS TCP (LISTENER_PORT = {{ mssql_ha_endpoint_port }});
     PRINT 'The LISTENER_PORT setting for the {{ mssql_ha_endpoint_name }} \
-endpoint updated to {{ mssql_ha_listener_port }} successfully';
+endpoint updated to {{ mssql_ha_endpoint_port }} successfully';
   END
   ELSE
   BEGIN
     PRINT 'The LISTENER_PORT setting for the {{ mssql_ha_endpoint_name }} \
-endpoint is already set to {{ mssql_ha_listener_port }}, skipping';
+endpoint is already set to {{ mssql_ha_endpoint_port }}, skipping';
   END
   IF NOT EXISTS (
     SELECT name, role_desc FROM sys.database_mirroring_endpoints

--- a/tests/templates/configure_ag_cluster_type_none.j2
+++ b/tests/templates/configure_ag_cluster_type_none.j2
@@ -2,7 +2,7 @@ CREATE AVAILABILITY GROUP {{ mssql_ha_ag_name }}
   WITH (CLUSTER_TYPE = NONE)
   FOR REPLICA ON
     N'{{ ansible_hostname }}' WITH (
-      ENDPOINT_URL = N'tcp://{{ ansible_fqdn }}:{{ mssql_ha_listener_port }}',
+      ENDPOINT_URL = N'tcp://{{ ansible_fqdn }}:{{ mssql_ha_endpoint_port }}',
       AVAILABILITY_MODE = SYNCHRONOUS_COMMIT,
       FAILOVER_MODE = MANUAL,
       SEEDING_MODE = AUTOMATIC,

--- a/tests/tests_configure_ha_cluster.yml
+++ b/tests/tests_configure_ha_cluster.yml
@@ -13,7 +13,7 @@
     mssql_version: 2019
     mssql_manage_firewall: true
     mssql_ha_configure: true
-    mssql_ha_listener_port: 5022
+    mssql_ha_endpoint_port: 5022
     mssql_ha_cert_name: ExampleCert
     mssql_ha_master_key_password: "p@55w0rD1"
     mssql_ha_private_key_password: "p@55w0rD2"
@@ -237,7 +237,7 @@
             in __mssql_sqlcmd_input.stdout
           - >-
             "The LISTENER_PORT setting for the {{ mssql_ha_endpoint_name }}
-            endpoint is already set to {{ mssql_ha_listener_port }}, skipping"
+            endpoint is already set to {{ mssql_ha_endpoint_port }}, skipping"
             in __mssql_sqlcmd_input.stdout
           - >-
             "The ROLE setting for the {{ mssql_ha_endpoint_name }} endpoint is
@@ -279,7 +279,7 @@
             in __mssql_sqlcmd_input.stdout
           - >-
             "The LISTENER_PORT setting for the {{ mssql_ha_endpoint_name }}
-            endpoint updated to {{ mssql_ha_listener_port }} successfully"
+            endpoint updated to {{ mssql_ha_endpoint_port }} successfully"
             in __mssql_sqlcmd_input.stdout
           - >-
             "The ROLE setting for the {{ mssql_ha_endpoint_name }}


### PR DESCRIPTION
As per feedback from Microsoft, mssql_ha_listener_port should be called HA communication port (or HA_log_transport_port),  as that port is used for the transaction log replication between primary and secondary replica. Listener is a term used for AG listener associated with AG which is used to route client connection to primary replica (or read only secondary replica based on configuration and request type).