### PR TITLE
deprecate set-output; update actions

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -15,7 +15,6 @@ skip_list:
   - fqcn-builtins
   - galaxy[no-changelog]
 exclude_paths:
-  - tests/playbooks/clean_up.yml
   - tests/roles/
   - .github/
   - examples/roles/

--- a/.github/workflows/changelog_to_tag.yml
+++ b/.github/workflows/changelog_to_tag.yml
@@ -62,20 +62,19 @@ jobs:
               git branch -a
               exit 1
           fi
-          echo ::set-output name=tagname::"$_tagname"
-          echo ::set-output name=branch::"$_branch"
+          echo tagname="$_tagname" >> "$GITHUB_OUTPUT"
+          echo branch="$_branch" >> "$GITHUB_OUTPUT"
       - name: Create tag
-        uses: mathieudutour/github-tag-action@v6.0
+        uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ steps.tag.outputs.tagname }}
           tag_prefix: ''
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ steps.tag.outputs.tagname }}
-          release_name: Version ${{ steps.tag.outputs.tagname }}
-          body_path: ./.tagmsg.txt
-          draft: false
-          prerelease: false
+          tag: ${{ steps.tag.outputs.tagname }}
+          name: Version ${{ steps.tag.outputs.tagname }}
+          bodyFile: ./.tagmsg.txt
+          makeLatest: true


### PR DESCRIPTION
The `set-output` has been deprecated - see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Some of the actions have been updated to fix this issue - update those actions

The `create-release` action has been deprecated
https://github.com/actions/create-release
the highest rated replacement is
https://github.com/marketplace/actions/create-release

reset existing commit after rebase to add without another commit

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

# Date:      Fri Jan 27 18:52:02 2023 -0700
#
# interactive rebase in progress; onto 70d998b
# Last commands done (4 commands done):
#    squash 6c249a9 reset existing commit after rebase to add without another commit
#    fixup 3c9a9e6 more
# No commands remaining.
# You are currently rebasing branch 'updates' on '70d998b'.
#
# Changes to be committed:
#	modified:   inventory/host_vars/journald.yml
#	modified:   inventory/inventory.yml
#	modified:   playbooks/templates/.github/workflows/changelog_to_tag.yml
#	modified:   playbooks/update_files.yml
#
# Untracked files:
#	.ansible-lint
#	git-commit-msg
#	graphql/
#	output
#	playbooks/graphql_files/
#	playbooks/update_branch_protection_rules.yml
#
