### PR TITLE
Version 1.3.0 - CHANGELOG.md [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ Changelog
     verbosity
   - Add collection-requirements.yml
   - Set the mssql_password variable to default null after test verification
+  - Add mssql_ad_netbios_name
+  - Add mssql_ad_sql_user_dn variable for flexibility
   
 ### Bug Fixes
 


### PR DESCRIPTION
[1.3.0-3 - 2023-02-16
--------------------

- Make AD integration functionality more flexible (#178)

  - Add mssql_ad_sql_user_dn variable for flexibility
  - Not everyone stores their service accounts in the Users OU
  - Use ad_integration_realm instead of ad_integration_realm when creating login
  - Add mssql_ad_netbios_name
  - Update tasks/main.yml
    Co-authored-by: Richard Megginson <rmeggins@redhat.com>
  - Add Verifying Authentication to README