### PR TITLE
ci: Add commitlint GitHub action to ensure conventional commits

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -15,7 +15,6 @@ kinds:
 skip_list:
   - fqcn-builtins
   - galaxy[no-changelog]
-  - galaxy[no-runtime]
 exclude_paths:
   - tests/roles/
   - .github/

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,60 @@
+name: Commitlint
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+  merge_group:
+    branches:
+      - main
+    types:
+      - checks_requested
+jobs:
+  commit-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install conventional-commit linter
+        run: npm install @commitlint/config-conventional @commitlint/cli
+
+      # Default config does not allow sentence case
+      # https://github.com/conventional-changelog/commitlint/blob/master/@commitlint/config-conventional/index.js
+      - name: Add conventional commits config and enable sentence case
+        run: |
+          echo "module.exports = {
+            extends: ['@commitlint/config-conventional'],
+            rules: {
+              'subject-case': [
+                2,
+                'never',
+                ['start-case', 'pascal-case', 'upper-case'],
+              ],
+            }
+          }" > commitlint.config.js
+
+      - name: Set commit range variables
+        # Finding the commit range is not as trivial as it may seem.
+        #
+        # At this stage, git's HEAD does not refer to the latest commit in the
+        # PR, but rather to the merge commit inserted by the PR. So instead we
+        # have to get 'HEAD' from the PR event.
+        #
+        # One cannot use the number of commits
+        # (github.event.pull_request.commits) to find the start commit
+        # i.e. HEAD~N does not work, this breaks if there are merge commits.
+        run: |
+          echo "PR_HEAD=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+          echo "PR_BASE=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
+
+      - name: Run commitlint on commits
+        run: npx commitlint --from $PR_BASE --to $PR_HEAD --verbose
+
+      - name: Run commitlint on PR title
+        run: |
+          echo ${{ github.event.pull_request.title }} | npx commitlint --verbose
+


### PR DESCRIPTION
For more information, see Conventional Commits format in Contribute
https://linux-system-roles.github.io/contribute.html#conventional-commits-format

Signed-off-by: Sergei Petrosian <spetrosi@redhat.com>
