### PR TITLE
feat: Support custom data and logs storage paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ The role also optimizes the operating system to improve performance and throughp
 
 ## Role Scenarios
 
+This section describes different scenarios that the role can accomplish.
+You can combine the scenarios by combining variables serving different scenarios into a larger playbook.
+
 ### Configuring General SQL Server Settings
 
 These variables apply to general SQL Server configuration.
@@ -293,6 +296,60 @@ Type: `string`
 The URL to the Microsoft production repository.
 
 Default: `{{ __mssql_client_repository }}`
+
+Type: `string`
+
+### Configuring Custom Data and Logs Storage Paths
+
+Optional: Use these variables to configure SQL Server to store data and logs in custom paths.
+
+#### Variables
+
+##### mssql_datadir
+
+The path to the directory that SQL Server must use to store data.
+When defined, the role creates the provided directory and ensures correct permissions and ownership for it.
+
+Note that if you change this path, the previously used directory and all it's content remains at the original path.
+
+Default: `null`
+
+Type: `string`
+
+##### mssql_datadir_mode
+
+The permissions to be set for the `mssql_datadir` path in the format of the Ansible `file` module `mode` variable.
+
+Quote the mode like `'0700'` so Ansible parses it as a string to avoid conflicts with octal numbers.
+
+If mode is not specified and the destination directory *does not* exist, the role uses the default umask on the system when setting the mode.
+If mode is not specified and the destination directory *does* exist, the role uses the mode of the existing directory.
+
+Default: `null`
+
+Type: `string`
+
+##### mssql_logdir
+
+The path to the directory that SQL Server must use to store logs.
+When defined, the role creates the provided directory and ensures correct permissions and ownership for it.
+
+Note that if you change this path, the previously used directory and all it's content remains at the original path.
+
+Default: `null`
+
+Type: `string`
+
+##### mssql_logdir_mode
+
+The permissions to be set for the `mssql_logdir` path in the format of the Ansible `file` module `mode` variable.
+
+Quote the mode like `'0700'` so Ansible parses it as a string to avoid conflicts with octal numbers.
+
+If mode is not specified and the destination directory *does not* exist, the role uses the default umask on the system when setting the mode.
+If mode is not specified and the destination directory *does* exist, the role uses the mode of the existing directory.
+
+Default: `null`
 
 Type: `string`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,16 +10,19 @@ mssql_edition: null
 mssql_tcp_port: 1433
 mssql_manage_firewall: false
 mssql_ip_address: null
-
-mssql_pre_input_sql_file: []
-mssql_post_input_sql_file: []
-mssql_debug: false
-
 mssql_enable_sql_agent: null
 mssql_install_fts: null
 mssql_install_powershell: null
 mssql_enable_ha: null
 mssql_tune_for_fua_storage: null
+mssql_datadir: null
+mssql_datadir_mode: null
+mssql_logdir: null
+mssql_logdir_mode: null
+
+mssql_pre_input_sql_file: []
+mssql_post_input_sql_file: []
+mssql_debug: false
 
 mssql_tls_enable: null
 mssql_tls_cert: null

--- a/tasks/configure_storage_paths.yml
+++ b/tasks/configure_storage_paths.yml
@@ -5,24 +5,20 @@
     path: "{{ __mssql_storage_path }}"
   register: __mssql_storage_path_stat
 
-- name: Ensure the directory and permissions for {{ __mssql_storage_path }}
-  # null converts to an empty string when setting vars in the parent task
-  when: __mssql_storage_mode != ''
-  file:
-    path: "{{ __mssql_storage_path }}"
-    state: directory
-    owner: mssql
-    group: mssql
-    mode: "{{ __mssql_storage_mode }}"
-
 - name: >-
     Ensure the directory and keep present permissions {{ __mssql_storage_path }}
-  when: __mssql_storage_mode == ''
   file:  # noqa risky-file-permissions
     path: "{{ __mssql_storage_path }}"
     state: directory
     owner: mssql
     group: mssql
+    mode: "{{
+      __mssql_storage_mode if __mssql_storage_mode != ''
+      else
+      __mssql_storage_path_stat.stat.mode
+      if __mssql_storage_path_stat.stat.exists
+      else
+      __mssql_storage_mode_default }}"
 
 - name: Configure the setting {{ __mssql_storage_setting }}
   include_tasks: mssql_conf_setting.yml

--- a/tasks/configure_storage_paths.yml
+++ b/tasks/configure_storage_paths.yml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Get stat of the directory {{ __mssql_storage_path }}
+  stat:
+    path: "{{ __mssql_storage_path }}"
+  register: __mssql_storage_path_stat
+
+- name: Ensure the directory and permissions for {{ __mssql_storage_path }}
+  # null converts to an empty string when setting vars in the parent task
+  when: __mssql_storage_mode != ''
+  file:
+    path: "{{ __mssql_storage_path }}"
+    state: directory
+    owner: mssql
+    group: mssql
+    mode: "{{ __mssql_storage_mode }}"
+
+- name: >-
+    Ensure the directory and keep present permissions {{ __mssql_storage_path }}
+  when: __mssql_storage_mode == ''
+  file:  # noqa risky-file-permissions
+    path: "{{ __mssql_storage_path }}"
+    state: directory
+    owner: mssql
+    group: mssql
+
+- name: Configure the setting {{ __mssql_storage_setting }}
+  include_tasks: mssql_conf_setting.yml
+  vars:
+    __mssql_conf_setting: filelocation {{ __mssql_storage_setting }}
+    __mssql_conf_setting_value: "{{ __mssql_storage_path }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -256,6 +256,21 @@
       fail:
         msg: "{{ ansible_failed_result.stderr_lines }}"
 
+- name: Ensure the directory and permissions for datadir and logdir
+  when: item.path is not none
+  loop:
+    - path: "{{ mssql_datadir }}"
+      mode: "{{ mssql_datadir_mode }}"
+      setting: defaultdatadir
+    - path: "{{ mssql_logdir }}"
+      mode: "{{ mssql_logdir_mode }}"
+      setting: defaultlogdir
+  include_tasks: configure_storage_paths.yml
+  vars:
+    __mssql_storage_path: "{{ item.path }}"
+    __mssql_storage_mode: "{{ item.mode }}"
+    __mssql_storage_setting: "{{ item.setting }}"
+
 - name: Ensure that the tuned-profiles-mssql package is installed
   package:
     name: tuned-profiles-mssql

--- a/tests/tasks/mssql_conf_verify.yml
+++ b/tests/tasks/mssql_conf_verify.yml
@@ -13,14 +13,13 @@
 
 - name: Verify the setting when it is type str {{ __mssql_conf_setting }}
   vars:
-    # basename is needed for settings that have path values, such as tlskey
     __mssql_conf_get_value: >-
       {{ __mssql_conf_get_setting.stdout |
-      regex_replace('^.*\s=\s', '') | string | lower | basename }}
+      regex_replace('^.*\s=\s', '') | string }}
   assert:
     that: __mssql_conf_get_value == __mssql_conf_value | string
   when:
-    - "__mssql_conf_value | type_debug == 'str'"
+    - __mssql_conf_value | type_debug != 'bool'
     - __mssql_conf_setting != "tcpport"
 
 - name: Verify the setting when it is type bool {{ __mssql_conf_setting }}

--- a/tests/tasks/verify_settings.yml
+++ b/tests/tasks/verify_settings.yml
@@ -25,11 +25,10 @@
         errorlog_edition="$(grep -oi '{{ __verify_mssql_edition }} edition' \
         {{ __mssql_errorlog.stdout }})"
         if [ -z "${errorlog_edition}" ]; then
-          edition_matches=false
+          echo false
         else
-          edition_matches=true
+          echo true
         fi
-        echo "${edition_matches}"
       register: __mssql_edition_matches
       changed_when: false
 
@@ -37,19 +36,48 @@
       assert:
         that: __mssql_edition_matches.stdout | bool
 
-- name: Verify the IP address setting
+- name: Verify the setting {{ item.key }}
+  with_dict:
+    ipaddress: "{{ __verify_mssql_ip_address }}"
+    tcpport: "{{ __verify_mssql_tcp_port }}"
+    defaultdatadir: "{{ __verify_mssql_datadir }}"
+    defaultlogdir: "{{ __verify_mssql_logdir }}"
+    enabled: "{{ __verify_mssql_agent_is_enabled }}"
+  when: item.value is defined
   include_tasks: mssql_conf_verify.yml
   vars:
-    __mssql_conf_setting: ipaddress
-    __mssql_conf_value: __mssql_ip_address_matches
-  when: __mssql_ip_address_matches is defined
+    __mssql_conf_setting: "{{ item.key }}"
+    __mssql_conf_value: "{{ item.value }}"
 
-- name: Verify the TCP port setting
-  include_tasks: mssql_conf_verify.yml
-  vars:
-    __mssql_conf_setting: tcpport
-    __mssql_conf_value: "{{ __mssql_tcp_port_matches }}"
-  when: __mssql_tcp_port_matches is defined
+- name: Verify mssql_datadir permissions and ownership
+  when: __verify_mssql_datadir_mode is defined
+  block:
+    - name: Get stat of mssql_datadir
+      stat:
+        path: "{{ __verify_mssql_datadir }}"
+      register: __mssql_datadir_stat
+
+    - name: Assert that mssql_datadir has proper permissions and ownership
+      assert:
+        that:
+          - __mssql_datadir_stat.stat.mode == __verify_mssql_datadir_mode
+          - __mssql_datadir_stat.stat.gr_name == 'mssql'
+          - __mssql_datadir_stat.stat.pw_name == 'mssql'
+
+- name: Verify mssql_logdir permissions and ownership
+  when: __verify_mssql_logdir_mode is defined
+  block:
+    - name: Get stat of mssql_logdir
+      stat:
+        path: "{{ __verify_mssql_logdir }}"
+      register: __mssql_logdir_stat
+
+    - name: Assert that mssql_logdir has proper permissions and ownership
+      assert:
+        that:
+          - __mssql_logdir_stat.stat.mode == __verify_mssql_logdir_mode
+          - __mssql_logdir_stat.stat.gr_name == 'mssql'
+          - __mssql_logdir_stat.stat.pw_name == 'mssql'
 
 - name: Verify password
   when: __verify_mssql_password is defined
@@ -82,13 +110,6 @@
     - name: Set the mssql_password variable to default null
       set_fact:
         mssql_password: null
-
-- name: Verify that the SQL agent is enabled
-  include_tasks: mssql_conf_verify.yml
-  vars:
-    __mssql_conf_setting: enabled
-    __mssql_conf_value: "{{ __verify_mssql_agent_is_enabled }}"
-  when: __verify_mssql_agent_is_enabled is defined
 
 - name: Verify the package {{ __mssql_server_fts_packages }}
   include_tasks: verify_package.yml
@@ -161,7 +182,8 @@
       vars:
         __mssql_conf_setting: tlscert
         __mssql_conf_value: >-
-          {{ mssql_tls_cert | basename if __verify_mssql_is_tls_encrypted
+          {{ '/etc/pki/tls/certs/' ~ mssql_tls_cert | basename
+          if __verify_mssql_is_tls_encrypted
           else '' }}
 
     - name: Verify the tlskey setting
@@ -169,8 +191,9 @@
       vars:
         __mssql_conf_setting: tlskey
         __mssql_conf_value: >-
-          {{ mssql_tls_private_key | basename if
-          __verify_mssql_is_tls_encrypted else '' }}
+          {{ '/etc/pki/tls/private/' ~ mssql_tls_private_key | basename
+          if __verify_mssql_is_tls_encrypted
+          else '' }}
 
     - name: Verify the tlsprotocols setting
       include_tasks: mssql_conf_verify.yml

--- a/tests/tests_idempotency_2017.yml
+++ b/tests/tests_idempotency_2017.yml
@@ -22,6 +22,10 @@
         mssql_enable_ha: true
         mssql_tune_for_fua_storage: true
         mssql_install_powershell: true
+        mssql_datadir: /tmp/data
+        mssql_logdir: /tmp/log
+        mssql_datadir_mode: '0700'
+        mssql_logdir_mode: '0700'
 
     - name: Configure the mssql-server service start limit interval and burst
       include_tasks: tasks/mssql-sever-increase-start-limit.yml
@@ -39,6 +43,8 @@
         mssql_enable_ha: true
         mssql_tune_for_fua_storage: true
         mssql_install_powershell: true
+        mssql_datadir: /tmp/data
+        mssql_logdir: /tmp/log
 
     - name: Verify settings
       include_tasks: tasks/verify_settings.yml
@@ -52,6 +58,10 @@
         __verify_mssql_ha_is_installed: true
         __verify_mssql_is_tuned_for_fua: true
         __verify_mssql_powershell_is_installed: true
+        __verify_mssql_datadir: /tmp/data
+        __verify_mssql_logdir: /tmp/log
+        __verify_mssql_datadir_mode: '0700'
+        __verify_mssql_logdir_mode: '0700'
 
     - name: Run to edit settings
       include_role:
@@ -66,6 +76,10 @@
         mssql_enable_ha: false
         mssql_tune_for_fua_storage: false
         mssql_install_powershell: false
+        mssql_datadir: /var/opt/mssql/data
+        mssql_logdir: /var/opt/mssql/log
+        mssql_datadir_mode: '0755'
+        mssql_logdir_mode: '0755'
 
     - name: Run with the edited settings again - should report not changed
       include_role:
@@ -80,6 +94,8 @@
         mssql_enable_ha: false
         mssql_tune_for_fua_storage: false
         mssql_install_powershell: false
+        mssql_datadir: /var/opt/mssql/data
+        mssql_logdir: /var/opt/mssql/log
 
     - name: Verify disabled settings
       include_tasks: tasks/verify_settings.yml
@@ -93,6 +109,10 @@
         __verify_mssql_ha_is_installed: false
         __verify_mssql_is_tuned_for_fua: false
         __verify_mssql_powershell_is_installed: false
+        __verify_mssql_datadir: /var/opt/mssql/data
+        __verify_mssql_logdir: /var/opt/mssql/log
+        __verify_mssql_datadir_mode: '0755'
+        __verify_mssql_logdir_mode: '0755'
 
     - name: Check the ansible_managed header in the configuration file
       include_tasks: tasks/check_header.yml

--- a/tests/tests_idempotency_2019.yml
+++ b/tests/tests_idempotency_2019.yml
@@ -22,6 +22,10 @@
         mssql_enable_ha: true
         mssql_tune_for_fua_storage: true
         mssql_install_powershell: true
+        mssql_datadir: /tmp/data
+        mssql_logdir: /tmp/log
+        mssql_datadir_mode: '0700'
+        mssql_logdir_mode: '0700'
 
     - name: Configure the mssql-server service start limit interval and burst
       include_tasks: tasks/mssql-sever-increase-start-limit.yml
@@ -39,6 +43,8 @@
         mssql_enable_ha: true
         mssql_tune_for_fua_storage: true
         mssql_install_powershell: true
+        mssql_datadir: /tmp/data
+        mssql_logdir: /tmp/log
 
     - name: Verify settings
       include_tasks: tasks/verify_settings.yml
@@ -52,6 +58,10 @@
         __verify_mssql_ha_is_installed: true
         __verify_mssql_is_tuned_for_fua: true
         __verify_mssql_powershell_is_installed: true
+        __verify_mssql_datadir: /tmp/data
+        __verify_mssql_logdir: /tmp/log
+        __verify_mssql_datadir_mode: '0700'
+        __verify_mssql_logdir_mode: '0700'
 
     - name: Run to edit settings
       include_role:
@@ -66,6 +76,10 @@
         mssql_enable_ha: false
         mssql_tune_for_fua_storage: false
         mssql_install_powershell: false
+        mssql_datadir: /var/opt/mssql/data
+        mssql_logdir: /var/opt/mssql/log
+        mssql_datadir_mode: '0755'
+        mssql_logdir_mode: '0755'
 
     - name: Run with the edited settings again - should report not changed
       include_role:
@@ -80,6 +94,8 @@
         mssql_enable_ha: false
         mssql_tune_for_fua_storage: false
         mssql_install_powershell: false
+        mssql_datadir: /var/opt/mssql/data
+        mssql_logdir: /var/opt/mssql/log
 
     - name: Verify disabled settings
       include_tasks: tasks/verify_settings.yml
@@ -93,6 +109,10 @@
         __verify_mssql_ha_is_installed: false
         __verify_mssql_is_tuned_for_fua: false
         __verify_mssql_powershell_is_installed: false
+        __verify_mssql_datadir: /var/opt/mssql/data
+        __verify_mssql_logdir: /var/opt/mssql/log
+        __verify_mssql_datadir_mode: '0755'
+        __verify_mssql_logdir_mode: '0755'
 
     - name: Check the ansible_managed header in the configuration file
       include_tasks: tasks/check_header.yml

--- a/tests/tests_idempotency_2022.yml
+++ b/tests/tests_idempotency_2022.yml
@@ -24,6 +24,10 @@
         mssql_enable_ha: true
         mssql_tune_for_fua_storage: true
         mssql_install_powershell: true
+        mssql_datadir: /tmp/data
+        mssql_logdir: /tmp/log
+        mssql_datadir_mode: '0700'
+        mssql_logdir_mode: '0700'
 
     - name: Configure the mssql-server service start limit interval and burst
       include_tasks: tasks/mssql-sever-increase-start-limit.yml
@@ -41,6 +45,8 @@
         mssql_enable_ha: true
         mssql_tune_for_fua_storage: true
         mssql_install_powershell: true
+        mssql_datadir: /tmp/data
+        mssql_logdir: /tmp/log
 
     - name: Verify settings
       include_tasks: tasks/verify_settings.yml
@@ -54,6 +60,10 @@
         __verify_mssql_ha_is_installed: true
         __verify_mssql_is_tuned_for_fua: true
         __verify_mssql_powershell_is_installed: true
+        __verify_mssql_datadir: /tmp/data
+        __verify_mssql_logdir: /tmp/log
+        __verify_mssql_datadir_mode: '0700'
+        __verify_mssql_logdir_mode: '0700'
 
     - name: Run to edit settings
       include_role:
@@ -68,6 +78,10 @@
         mssql_enable_ha: false
         mssql_tune_for_fua_storage: false
         mssql_install_powershell: false
+        mssql_datadir: /var/opt/mssql/data
+        mssql_logdir: /var/opt/mssql/log
+        mssql_datadir_mode: '0755'
+        mssql_logdir_mode: '0755'
 
     - name: Run with the edited settings again - should report not changed
       include_role:
@@ -82,6 +96,8 @@
         mssql_enable_ha: false
         mssql_tune_for_fua_storage: false
         mssql_install_powershell: false
+        mssql_datadir: /var/opt/mssql/data
+        mssql_logdir: /var/opt/mssql/log
 
     - name: Verify disabled settings
       include_tasks: tasks/verify_settings.yml
@@ -95,6 +111,10 @@
         __verify_mssql_ha_is_installed: false
         __verify_mssql_is_tuned_for_fua: false
         __verify_mssql_powershell_is_installed: false
+        __verify_mssql_datadir: /var/opt/mssql/data
+        __verify_mssql_logdir: /var/opt/mssql/log
+        __verify_mssql_datadir_mode: '0755'
+        __verify_mssql_logdir_mode: '0755'
 
     - name: Check the ansible_managed header in the configuration file
       include_tasks: tasks/check_header.yml


### PR DESCRIPTION
Previously, the role was configuring the default data and logs storage
paths. Currently, you can provide custom storage paths with variables
`mssql_datadir` and `mssql_logdir`, and optionally set permissions for
the custom paths with `mssql_datadir_mode` and `mssql_logdir_mode`
variables.