### PR TITLE
ci: update tox-lsr to version 3.0.0

### DIFF
--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.2"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.0.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.2"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.0.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.2"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.0.0"
 
       - name: Convert role to collection format
         run: |

--- a/contributing.md
+++ b/contributing.md
@@ -1,24 +1,24 @@
-Contributing to the Mssql Linux System Role
-=============================================
+Contributing to the mssql Linux System Role
+===========================================
 
 Where to start
 --------------
 
 The first place to go is [Contribute](https://linux-system-roles.github.io/contribute.html).
 This has all of the common information that all role developers need:
+
 * Role structure and layout
 * Development tools - How to run tests and checks
 * Ansible recommended practices
 * Basic git and github information
 * How to create git commits and submit pull requests
 
-- **Bugs and needed implementations** are listed on [Github
-  Issues](https://github.com/linux-system-roles/mssql/issues). Issues labeled with
-[**help
-wanted**](https://github.com/linux-system-roles/mssql/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+**Bugs and needed implementations** are listed on
+[Github Issues](https://github.com/linux-system-roles/mssql/issues).
+Issues labeled with
+[**help wanted**](https://github.com/linux-system-roles/mssql/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
 are likely to be suitable for new contributors!
 
-- **Code** is managed on
-  [Github](https://github.com/linux-system-roles/mssql), using [Pull
-Requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests).
+**Code** is managed on [Github](https://github.com/linux-system-roles/mssql), using
+[Pull Requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests).
 


### PR DESCRIPTION
The major version bump is because tox-lsr 3 drops support
for tox version 2.  If you are using tox 2 you will need to
upgrade to tox 3 or 4.

tox-lsr 3.0.0 adds support for tox 4, commitlint, and ansible-lint-collection

See https://github.com/linux-system-roles/tox-lsr/releases/tag/3.0.0
for full release notes

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
