### PR TITLE
fix: Remove outdated and confusing mssql_enable_ha variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,6 @@ Default: `null`
 
 Type: `bool`
 
-##### mssql_enable_ha
-
-Optional: Set this variable to `true` or `false` to install or remove the `mssql-server-ha` package and enable or disable the `hadrenabled` setting.
-
-Default: `null`
-
-Type: `bool`
-
 ##### mssql_tune_for_fua_storage
 
 Optional: Set this variable to `true` or `false` to enable or disable settings that improve performance on hosts that support Forced Unit Access (FUA) capability.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,6 @@ mssql_ip_address: null
 mssql_enable_sql_agent: null
 mssql_install_fts: null
 mssql_install_powershell: null
-mssql_enable_ha: null
 mssql_tune_for_fua_storage: null
 mssql_datadir: null
 mssql_datadir_mode: null

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -534,21 +534,6 @@
     state: "{{ 'present' if mssql_install_powershell | bool else 'absent' }}"
   when: mssql_install_powershell is not none
 
-- name: Configure HA
-  when: mssql_enable_ha is not none
-  block:
-    - name: Ensure the package {{ __mssql_server_ha_packages }}
-      package:
-        name: "{{ __mssql_server_ha_packages }}"
-        state: "{{ 'present' if mssql_enable_ha | bool else 'absent' }}"
-      notify: Restart the mssql-server service
-
-    - name: Configure the hadrenabled setting
-      include_tasks: mssql_conf_setting.yml
-      vars:
-        __mssql_conf_setting: "hadr hadrenabled"
-        __mssql_conf_setting_value: "{{ 1 if mssql_enable_ha else 0 }}"
-
 - name: Tune MSSQL for FUA-capable storage
   when: mssql_tune_for_fua_storage is not none
   block:

--- a/tests/tasks/tests_idempotency.yml
+++ b/tests/tasks/tests_idempotency.yml
@@ -13,7 +13,6 @@
     mssql_ip_address: 0.0.0.0
     mssql_enable_sql_agent: true
     mssql_install_fts: true
-    mssql_enable_ha: true
     mssql_tune_for_fua_storage: true
     mssql_install_powershell: true
     mssql_datadir: /tmp/data
@@ -34,7 +33,6 @@
     mssql_ip_address: 0.0.0.0
     mssql_enable_sql_agent: true
     mssql_install_fts: true
-    mssql_enable_ha: true
     mssql_tune_for_fua_storage: true
     mssql_install_powershell: true
     mssql_datadir: /tmp/data
@@ -67,7 +65,6 @@
     mssql_ip_address: 127.0.0.1
     mssql_enable_sql_agent: false
     mssql_install_fts: false
-    mssql_enable_ha: false
     mssql_tune_for_fua_storage: false
     mssql_install_powershell: false
     mssql_datadir: /var/opt/mssql/data
@@ -85,7 +82,6 @@
     mssql_ip_address: 127.0.0.1
     mssql_enable_sql_agent: false
     mssql_install_fts: false
-    mssql_enable_ha: false
     mssql_tune_for_fua_storage: false
     mssql_install_powershell: false
     mssql_datadir: /var/opt/mssql/data


### PR DESCRIPTION
It has a very limited functionality, the proper HA functionality is available with the mssql_ha_configure variable