### PR TITLE
fix: Only do an upgrade if there is a current version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -138,7 +138,9 @@
     state: present
 
 - name: Prepare for the upgrade
-  when: mssql_upgrade | bool
+  when:
+    - __mssql_current_version is defined
+    - mssql_upgrade | bool
   block:
     # This works only on systems that use yum or dnf
     - name: >-


### PR DESCRIPTION
Enhancement:
Skip Prepare upgrade step if there is no current version

Reason:
Having `mssql_upgrade` enabled, while there is no current version installed failed with undefined variable `__mssql_current_version`. 

Result:
If no current version is installed, the prepare upgrade task is skipped and a fresh installation is done.
