### PR TITLE
feat: Add mssql_ad_join and mssql_ad_kerberos_user to allow using other domain join methods

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,6 +54,8 @@ mssql_ha_virtual_ip: null
 mssql_ha_cluster_run_role: false
 
 mssql_ad_configure: false
+mssql_ad_join: true
+mssql_ad_obtain_kerberos: true
 mssql_ad_sql_user_name: null
 mssql_ad_sql_password: null
 # Default to CN={{ mssql_ad_sql_user_name }},CN=Users,DC=DOMAIN,DC=SUBDOMAIN...

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,7 +55,6 @@ mssql_ha_cluster_run_role: false
 
 mssql_ad_configure: false
 mssql_ad_join: true
-mssql_ad_obtain_kerberos: true
 mssql_ad_sql_user_name: null
 mssql_ad_sql_password: null
 # Default to CN={{ mssql_ad_sql_user_name }},CN=Users,DC=DOMAIN,DC=SUBDOMAIN...
@@ -68,3 +67,9 @@ mssql_ad_sql_user_dn: >-
 mssql_ad_netbios_name: "{{ ad_integration_realm.split('.') | first }}"
 mssql_ad_keytab_file: null
 mssql_ad_keytab_remote_src: false
+mssql_ad_kerberos_user: >-
+  {{ ad_integration_user if ad_integration_user is defined
+  else mssql_ad_sql_user_name }}
+mssql_ad_kerberos_password: >-
+  {{ ad_integration_password if ad_integration_user is defined
+  else mssql_ad_sql_password }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -656,39 +656,31 @@
         __mssql_conf_setting_value: "{{ '1' if mssql_tls_enable else 'unset' }}"
 
 - name: Configure Active Directory authentication
-  vars:
-    __mssql_kinit_user: >-
-      {{ ad_integration_user }}@{{ ad_integration_realm | upper }}
   when: mssql_ad_configure | bool
   block:
-    - name: Verify that required variables are provided
+    - name: Verify that ad_integration_realm variable is provided
+      when:
+        - mssql_ad_join | bool
+        - mssql_ad_keytab_file is none
       assert:
         that: ad_integration_realm is defined
-
-    - name: Verify if the mssql_ad_obtain_kerberos var is provided correctly
-      when: mssql_ad_obtain_kerberos | bool
-      assert:
-        that:
-          - ad_integration_user is defined
-          - ad_integration_password is defined
-        fail_msg: >-
-          You have mssql_ad_obtain_kerberos set to true.
-          You must set ad_integration_user and ad_integration_password variables
-          to obtain Kerberos ticket.
-
-    - name: Ensure adutil
-      package:
-        name: adutil
-        state: present
+        fail_msg: You must provide the ad_integration_realm variable
 
     - name: Join to realm {{ ad_integration_realm }}
       include_role:
         name: fedora.linux_system_roles.ad_integration
       when: mssql_ad_join | bool
 
-    - name: Obtain Kerberos ticket
-      when: mssql_ad_obtain_kerberos
+    - name: Ensure AD user and create keytab file
+      when: mssql_ad_keytab_file is none
       block:
+        - name: Ensure adutil and krb5-workstation
+          package:
+            name:
+              - adutil
+              - krb5-workstation
+            state: present
+
         - name: Print credential caches to check if AD principal exists
           command: klist -l
           register: __mssql_klist
@@ -696,32 +688,29 @@
           failed_when: false
 
         # Do not fail when there are no tickets
-        - name: Print status of credential cache for {{ __mssql_kinit_user }}
+        - name: Print status of credential cache for {{ __mssql_ad_kinit_user }}
           shell: >-
             set -euo pipefail;
-            klist -l $(klist -l | grep {{ __mssql_kinit_user }}
+            klist -l $(klist -l | grep {{ __mssql_ad_kinit_user }}
             | awk '{print $2}')
           register: __mssql_klist_kinit_user
-          when: __mssql_kinit_user in __mssql_klist.stdout
+          when: __mssql_ad_kinit_user in __mssql_klist.stdout
           changed_when: false
 
-        - name: Obtain Kerberos ticket of the AD user {{ ad_integration_user }}
+        - name: Obtain Kerberos ticket for {{ __mssql_ad_kinit_user }}
           shell: >-
             set -euo pipefail;
-            echo {{ ad_integration_password | quote }}
-            | kinit {{ __mssql_kinit_user }}
+            echo {{ mssql_ad_kerberos_password | quote }}
+            | kinit {{ __mssql_ad_kinit_user }}
           when: >-
-            (__mssql_kinit_user not in __mssql_klist.stdout)
+            (__mssql_ad_kinit_user not in __mssql_klist.stdout)
             or
             ("(Expired)" in __mssql_klist_kinit_user.stdout | d())
           no_log: true
           changed_when: true
 
-    - name: Create keytab file
-      when: mssql_ad_keytab_file is none
-      block:
         # Do not fail if account does not exist
-        - name: Check if SQL user exists {{ mssql_ad_sql_user_name }}
+        - name: Check if AD user exists {{ mssql_ad_sql_user_name }}
           command: >-
             adutil account exists
             --name {{ mssql_ad_sql_user_name }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -661,17 +661,33 @@
       {{ ad_integration_user }}@{{ ad_integration_realm | upper }}
   when: mssql_ad_configure | bool
   block:
-    - name: Join to realm {{ ad_integration_realm }}
-      include_role:
-        name: fedora.linux_system_roles.ad_integration
+    - name: Verify that required variables are provided
+      assert:
+        that: ad_integration_realm is defined
 
-    - name: Ensure the adutil package
+    - name: Verify if the mssql_ad_obtain_kerberos var is provided correctly
+      when: mssql_ad_obtain_kerberos | bool
+      assert:
+        that:
+          - ad_integration_user is defined
+          - ad_integration_password is defined
+        fail_msg: >-
+          You have mssql_ad_obtain_kerberos set to true.
+          You must set ad_integration_user and ad_integration_password variables
+          to obtain Kerberos ticket.
+
+    - name: Ensure adutil
       package:
         name: adutil
         state: present
 
-    - name: Create keytab file
-      when: mssql_ad_keytab_file is none
+    - name: Join to realm {{ ad_integration_realm }}
+      include_role:
+        name: fedora.linux_system_roles.ad_integration
+      when: mssql_ad_join | bool
+
+    - name: Obtain Kerberos ticket
+      when: mssql_ad_obtain_kerberos
       block:
         - name: Print credential caches to check if AD principal exists
           command: klist -l
@@ -701,6 +717,9 @@
           no_log: true
           changed_when: true
 
+    - name: Create keytab file
+      when: mssql_ad_keytab_file is none
+      block:
         # Do not fail if account does not exist
         - name: Check if SQL user exists {{ mssql_ad_sql_user_name }}
           command: >-
@@ -710,27 +729,6 @@
           register: __mssql_adutil_account_exists
           changed_when: false
           failed_when: false
-
-        - name: Verify password provided for user {{ mssql_ad_sql_user_name }}
-          command: >-
-            sshpass -p {{ mssql_ad_sql_password | quote }}
-            ssh -o StrictHostKeyChecking=no
-            -l {{ mssql_ad_sql_user_name }}@{{ ad_integration_realm }}
-            {{ ansible_fqdn }} id
-          register: __mssql_sql_user_ssh
-          ignore_errors: true
-          changed_when: false
-          when: __mssql_adutil_account_exists.stdout | bool
-          no_log: true
-
-        - name: Update password for the SQL user {{ mssql_ad_sql_user_name }}
-          command: >-
-            adutil account setpassword
-            --name {{ mssql_ad_sql_user_name }}
-            --password {{ mssql_ad_sql_password | quote }}
-          when: __mssql_sql_user_ssh is failed
-          no_log: true
-          changed_when: true
 
         - name: In AD server create user {{ mssql_ad_sql_user_name }}
           command: >-

--- a/tasks/sqlcmd_input_file.yml
+++ b/tasks/sqlcmd_input_file.yml
@@ -4,7 +4,7 @@
     - name: Create a tempfile on the host for {{ item }}
       tempfile:
         state: file
-        prefix: "{{ item | splitext | first }}_"
+        prefix: "{{ item | basename }}_"
         suffix: .sql
       register: __mssql_sql_tempfile
       changed_when: false

--- a/tests/playbooks/tests_ad_integration.yml
+++ b/tests/playbooks/tests_ad_integration.yml
@@ -101,40 +101,9 @@
         name: linux-system-roles.mssql
       vars:
         mssql_ad_join: false
-        ad_integration_manage_dns: null
-        ad_integration_dns_server: null
-        ad_integration_dns_connection_name: null
-        ad_integration_dns_connection_type: null
-
-    - name: Test AD integration
-      include_tasks: ../tasks/verify_ad_auth.yml
-
-    - name: Clean up after the role invocation
-      include_tasks: ../tasks/cleanup.yml
-
-    # Test with mssql_ad_join: false and mssql_ad_obtain_kerberos: false
-    - name: Authenticate to AD
-      include_role:
-        name: linux-system-roles.ad_integration
-
-    - name: Ensure krb5-workstation
-      package:
-        name: krb5-workstation
-        state: present
-
-    - name: Obtain Kerberos ticket of the AD user {{ ad_integration_user }}
-      shell: >-
-        set -euo pipefail;
-        echo {{ ad_integration_password | quote }}
-        | kinit {{ ad_integration_user }}@{{ ad_integration_realm | upper }}
-      changed_when: true
-
-    - name: Configure AD without joining to AD and without obtaining Kerberos
-      include_role:
-        name: linux-system-roles.mssql
-      vars:
-        mssql_ad_join: false
-        mssql_ad_obtain_kerberos: false
+        # Explicitly set kerberos vars, otherwise the value becomes null
+        mssql_ad_kerberos_user: Administrator
+        mssql_ad_kerberos_password: Secret123
         ad_integration_user: null
         ad_integration_password: null
         ad_integration_manage_dns: null

--- a/tests/playbooks/tests_ad_integration.yml
+++ b/tests/playbooks/tests_ad_integration.yml
@@ -34,13 +34,14 @@
     mssql_ad_sql_user_name: sqluser
     mssql_ad_sql_password: "p@55w0rD1"
     ad_integration_realm: domain.com
-    ad_integration_password: Secret123
     ad_integration_user: Administrator
+    ad_integration_password: Secret123
     ad_integration_manage_dns: true
     ad_integration_dns_server: 1.1.1.1
     ad_integration_dns_connection_name: eth0
     ad_integration_dns_connection_type: ethernet
   tasks:
+    # Test general scenario
     - name: Set up MSSQL and configure AD authentication
       include_role:
         name: linux-system-roles.mssql
@@ -62,37 +63,9 @@
       delegate_to: ad
 
     - name: Test AD integration
-      block:
-        - name: Install sshpass for use in the following task
-          package:
-            name: sshpass
-            state: present
+      include_tasks: ../tasks/verify_ad_auth.yml
 
-        - name: SSH into AD, kinit as Administrator, verify authentication
-          vars:
-            __mssql_kinit_user: >-
-              {{ ad_integration_user }}@{{ ad_integration_realm
-              | upper }}
-          shell: >-
-            set -euo pipefail;
-            sshpass -p {{ mssql_ad_sql_password | quote }}
-            ssh -o StrictHostKeyChecking=no
-            -l {{ mssql_ad_sql_user_name }}@{{ ad_integration_realm }}
-            {{ ansible_fqdn }}
-            "echo {{ ad_integration_password | quote }}
-            | kinit {{ __mssql_kinit_user }} &&
-            /opt/mssql-tools/bin/sqlcmd -S. -Q 'SELECT SYSTEM_USER'"
-          register: __mssql_ad_test
-          changed_when: false
-      always:
-        - name: Print test results
-          debug:
-            var: __mssql_ad_test.stdout_lines
-
-        - name: Print test results
-          debug:
-            var: __mssql_ad_test.stderr_lines
-
+    # Test with mssql_ad_keytab_file
     - name: Fetch keytab file that was prepared above
       fetch:
         src: /var/opt/mssql/secrets/mssql.keytab
@@ -112,37 +85,62 @@
       include_role:
         name: linux-system-roles.mssql
 
-    - name: Test AD integration with keytab
+    - name: Test AD integration
+      include_tasks: ../tasks/verify_ad_auth.yml
+
+    - name: Clean up after the role invocation
+      include_tasks: ../tasks/cleanup.yml
+
+    # Test with mssql_ad_join: false
+    - name: Authenticate to AD
+      include_role:
+        name: linux-system-roles.ad_integration
+
+    - name: Set up MSSQL and configure AD authentication without joining to AD
+      include_role:
+        name: linux-system-roles.mssql
       vars:
-        __mssql_kinit_user: >-
-          {{ ad_integration_user }}@{{ ad_integration_realm
-          | upper }}
-      block:
-        - name: Obtain Kerberos ticket of the AD user {{ ad_integration_user }}
-          shell: >-
-            set -euo pipefail;
-            echo {{ ad_integration_password | quote }}
-            | kinit {{ __mssql_kinit_user }}
-          no_log: true
-          changed_when: true
+        mssql_ad_join: false
+        ad_integration_manage_dns: null
+        ad_integration_dns_server: null
+        ad_integration_dns_connection_name: null
+        ad_integration_dns_connection_type: null
 
-        - name: SSH into AD, kinit as Administrator, verify authentication
-          shell: >-
-            set -euo pipefail;
-            sshpass -p {{ mssql_ad_sql_password | quote }}
-            ssh -o StrictHostKeyChecking=no
-            -l {{ mssql_ad_sql_user_name }}@{{ ad_integration_realm }}
-            {{ ansible_fqdn }}
-            "echo {{ ad_integration_password | quote }}
-            | kinit {{ __mssql_kinit_user }} &&
-            /opt/mssql-tools/bin/sqlcmd -S. -Q 'SELECT SYSTEM_USER'"
-          register: __mssql_ad_test
-          changed_when: false
-      always:
-        - name: Print test results
-          debug:
-            var: __mssql_ad_test.stdout_lines
+    - name: Test AD integration
+      include_tasks: ../tasks/verify_ad_auth.yml
 
-        - name: Print test results
-          debug:
-            var: __mssql_ad_test.stderr_lines
+    - name: Clean up after the role invocation
+      include_tasks: ../tasks/cleanup.yml
+
+    # Test with mssql_ad_join: false and mssql_ad_obtain_kerberos: false
+    - name: Authenticate to AD
+      include_role:
+        name: linux-system-roles.ad_integration
+
+    - name: Ensure krb5-workstation
+      package:
+        name: krb5-workstation
+        state: present
+
+    - name: Obtain Kerberos ticket of the AD user {{ ad_integration_user }}
+      shell: >-
+        set -euo pipefail;
+        echo {{ ad_integration_password | quote }}
+        | kinit {{ ad_integration_user }}@{{ ad_integration_realm | upper }}
+      changed_when: true
+
+    - name: Configure AD without joining to AD and without obtaining Kerberos
+      include_role:
+        name: linux-system-roles.mssql
+      vars:
+        mssql_ad_join: false
+        mssql_ad_obtain_kerberos: false
+        ad_integration_user: null
+        ad_integration_password: null
+        ad_integration_manage_dns: null
+        ad_integration_dns_server: null
+        ad_integration_dns_connection_name: null
+        ad_integration_dns_connection_type: null
+
+    - name: Test AD integration
+      include_tasks: ../tasks/verify_ad_auth.yml

--- a/tests/tasks/verify_ad_auth.yml
+++ b/tests/tasks/verify_ad_auth.yml
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Test AD integration with keytab
+  vars:
+    __mssql_kinit_user: >-
+      {{ ad_integration_user }}@{{ ad_integration_realm
+      | upper }}
+  block:
+    - name: Install sshpass for use in the following task
+      package:
+        name: sshpass
+        state: present
+
+    - name: Print credential caches to check if AD principal exists
+      command: klist -l
+      register: __mssql_klist
+      changed_when: false
+      failed_when: false
+
+    # Do not fail when there are no tickets
+    - name: Print status of credential cache for {{ __mssql_kinit_user }}
+      shell: >-
+        set -euo pipefail;
+        klist -l $(klist -l | grep {{ __mssql_kinit_user }}
+        | awk '{print $2}')
+      register: __mssql_klist_kinit_user
+      when: __mssql_kinit_user in __mssql_klist.stdout
+      changed_when: false
+
+    - name: Obtain Kerberos ticket of the AD user {{ ad_integration_user }}
+      shell: >-
+        set -euo pipefail;
+        echo {{ ad_integration_password | quote }}
+        | kinit {{ __mssql_kinit_user }}
+      when: >-
+        (__mssql_kinit_user not in __mssql_klist.stdout)
+        or
+        ("(Expired)" in __mssql_klist_kinit_user.stdout | d())
+      changed_when: true
+
+    - name: Create the privileged account login
+      vars:
+        __mssql_sql_files_to_input:
+          - tests/templates/ad_create_login.j2
+        __mssql_ad_user: >-
+          {{ ad_integration_realm.split('.') | first }}\{{
+          ad_integration_user }}
+      include_role:
+        name: linux-system-roles.mssql
+        tasks_from: input_sql_files.yml
+
+    - name: SSH into AD, kinit as Administrator, verify authentication
+      shell: >-
+        set -euo pipefail;
+        sshpass -p {{ mssql_ad_sql_password | quote }}
+        ssh -o StrictHostKeyChecking=no
+        -l {{ mssql_ad_sql_user_name }}@{{ ad_integration_realm }}
+        {{ ansible_fqdn }}
+        "echo {{ ad_integration_password | quote }}
+        | kinit {{ __mssql_kinit_user }} &&
+        /opt/mssql-tools/bin/sqlcmd -S. -Q 'SELECT SYSTEM_USER'"
+      register: __mssql_ad_test
+      changed_when: false
+  always:
+    - name: Print test results
+      debug:
+        var: __mssql_ad_test.stdout_lines
+
+    - name: Print test results
+      debug:
+        var: __mssql_ad_test.stderr_lines

--- a/tests/templates/ad_create_login.j2
+++ b/tests/templates/ad_create_login.j2
@@ -1,0 +1,14 @@
+USE master;
+IF NOT EXISTS (
+  SELECT name FROM sys.server_principals
+  WHERE name = '{{ __mssql_ad_user }}'
+)
+BEGIN
+  PRINT 'A {{ __mssql_ad_user }} login does not exist, creating';
+  CREATE LOGIN [{{ __mssql_ad_user }}] FROM WINDOWS;
+  PRINT 'The {{ __mssql_ad_user }} login created successfully';
+END
+ELSE
+BEGIN
+  PRINT 'A {{ __mssql_ad_user }} login already exists, skipping'
+END

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -55,3 +55,6 @@ __mssql_ha_db_failover: >-
   {%- endif -%}
 __mssql_ha_cert_dest: /var/opt/mssql/data/{{ mssql_ha_cert_name }}.cer
 __mssql_ha_private_key_dest: /var/opt/mssql/data/{{ mssql_ha_cert_name }}.pvk
+
+__mssql_ad_kinit_user: >-
+  {{ mssql_ad_kerberos_user }}@{{ ad_integration_realm | upper }}


### PR DESCRIPTION
Enhancement:
1. Add the `mssql_ad_join` variable to allow using other domain join methods.
2. Add the `mssql_ad_kerberos_user` and `mssql_ad_kerberos_password` variables to allow users to specify a user to obtain kerberos ticket for in the case that default user doesn't match.

Reason: Sometimes, users use other methods to manage joining to AD that would be broken if that role were to run.

Result:
1. Users can set `mssql_ad_join` to `false` and join managed nodes to AD themselves prior to running the role. By default, `mssql_ad_join` = `true`, so the current behavior is not changed.
2. Users can set `mssql_ad_kerberos_user` and `mssql_ad_kerberos_password` to obtain a kerberos ticket for a specific use if the user that the role selects by default doesn't work for them.

Issue Tracker Tickets (Jira or BZ if any):
Resolves #210 