### PR TITLE
feat: Add the ability to input T-SQL scripts content in addition to files

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,18 @@ Type: `bool`
 
 ### Inputting SQL Scripts to SQL Server
 
-Optional: Use these variables to input T-SQL scripts to SQL Server.
+Optional: You can use the role to input T-SQL statements or procedures into SQL Server.
+
+You can either input a file containing T-SQL code or the code directly.
+You can use on of the following methods:
+1. With [`mssql_pre_input_sql_file and mssql_post_input_sql_file`](#mssql_pre_input_sql_file-and-mssql_post_input_sql_file), you can input a file containing T-SQL code.
+2. With [`mssql_pre_input_sql_content and mssql_post_input_sql_content`](#mssql_pre_input_sql_content-and-mssql_post_input_sql_content), you can input T-SQL code directly.
+
+When specifying any of these variables, you must also specify the `mssql_password` variable because authentication is required to input an SQL file to SQL Server.
+
+Note that the input task is not idempotent, the role always inputs an SQL file if any of these variables is defined.
+
+You can find an example of an SQL script at the role's `tests/files` directory.
 
 #### Variables
 
@@ -189,19 +200,10 @@ This variable is deprecated. Use the below variables instead.
 
 With these variables, enter the path to the files containing SQL scripts.
 
-You can use the role to input a file containing SQL statements or procedures into SQL Server.
-
 * Use `mssql_pre_input_sql_file` to input the SQL file immediately after the role configures SQL Server.
 * Use `mssql_post_input_sql_file` to input the SQL file at the end of the role invocation.
 
-When specifying any of these variables, you must also specify the `mssql_password` variable because authentication is required to input an SQL file to SQL Server.
-
-Note that this task is not idempotent, the role always inputs an SQL file if any of these variables is defined.
-
-You can find an example of an SQL script at `tests/sql_script.sql` at the role directory.
-
 You can set these variables to a list of files, or to a string containing a single file.
-
 
 Default: `null`
 
@@ -211,16 +213,8 @@ Type: `string` or `list`
 
 With these variables, enter SQL scripts directly.
 
-You can use the role to input T-SQL statements or procedures into SQL Server.
-
 * Use `mssql_pre_input_sql_content` to input SQL scripts immediately after the role configures SQL Server.
 * Use `mssql_post_input_sql_content` to input SQL scripts at the end of the role invocation.
-
-When specifying any of these variables, you must also specify the `mssql_password` variable because authentication is required to input an SQL file to SQL Server.
-
-Note that this task is not idempotent, the role always inputs SQL scripts if any of these variables is defined.
-
-You can find an example of an SQL script at `tests/sql_script.sql` at the role directory.
 
 You can set these variables to a list of scripts, or to a string containing a single script.
 
@@ -230,8 +224,7 @@ Type: `string` or `list`
 
 ##### mssql_debug
 
-Whether to print the output of sqlcmd commands.
-The role inputs SQL scripts with the sqlcmd command to configure SQL Server for HA or to input users' SQL scripts when you define of of [`mssql_pre_input_sql_file`](#mssql_pre_input_sql_file-and-mssql_post_input_sql_file), [`mssql_post_input_sql_file`](#mssql_pre_input_sql_file-and-mssql_post_input_sql_file), ['mssql_pre_input_sql_content'](#mssql_pre_input_sql_content-and-mssql_post_input_sql_content), ['mssql_post_input_sql_content](#mssql_pre_input_sql_content-and-mssql_post_input_sql_content) variables.
+Whether to print the output of sqlcmd commands when inputting T-SQL statements and procedures.
 
 Default: `false`
 
@@ -240,8 +233,6 @@ Type: `bool`
 #### Example Playbooks
 
 ##### Inputting SQL script files and content to SQL Server
-
-This example makes use of [`mssql_pre_input_sql_file`](#mssql_pre_input_sql_file-and-mssql_post_input_sql_file), [`mssql_post_input_sql_file`](#mssql_pre_input_sql_file-and-mssql_post_input_sql_file), ['mssql_pre_input_sql_content'](#mssql_pre_input_sql_content-and-mssql_post_input_sql_content), and ['mssql_post_input_sql_content](#mssql_pre_input_sql_content-and-mssql_post_input_sql_content) variables.
 
 ```yaml
 - hosts: all

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,8 @@ mssql_logdir_mode: null
 
 mssql_pre_input_sql_file: []
 mssql_post_input_sql_file: []
+mssql_pre_input_sql_content: []
+mssql_post_input_sql_content: []
 mssql_debug: false
 
 mssql_tls_enable: null

--- a/tasks/input_sql_files.yml
+++ b/tasks/input_sql_files.yml
@@ -36,6 +36,12 @@
     (__mssql_sqlcmd_login_cmd is none) or
     (__mssql_sqlcmd_login_cmd is not defined)
 
-- name: Input SQL files to MSSQL
+- name: Input SQL script files to MSSQL
   include_tasks: sqlcmd_input_file.yml
   loop: "{{ __mssql_sql_files_to_input }}"
+  when: __mssql_sql_files_to_input is defined
+
+- name: Input SQL script contents to MSSQL
+  include_tasks: sqlcmd_input_content.yml
+  loop: "{{ __mssql_sql_content_to_input }}"
+  when: __mssql_sql_content_to_input is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -403,7 +403,7 @@
               not "Unable to set the system administrator password. Please
               consult the ERRORLOG" in __mssql_set_ha_password.stdout
 
-# Input files var as list even when provided as sting
+# Input files var as list even when provided as a string
 # Keep these 2 tasks after setting password
 - name: Pre-input SQL script files to SQL Server
   vars:
@@ -415,7 +415,7 @@
   include_tasks: input_sql_files.yml
   when: mssql_pre_input_sql_file != []
 
-# Input content as list even when provided as sting
+# Input content as list even when provided as a string
 - name: Pre-input SQL script contents to SQL Server
   vars:
     __mssql_sql_content_to_input: "{{
@@ -1212,7 +1212,7 @@
 - name: Flush handlers prior to inputting post SQL scripts
   meta: flush_handlers
 
-# Input files var as list even when provided as sting
+# Input files var as list even when provided as a string
 - name: Post-input SQL scripts to SQL Server
   vars:
     __mssql_sql_files_to_input: "{{
@@ -1223,7 +1223,7 @@
   include_tasks: input_sql_files.yml
   when: mssql_post_input_sql_file != []
 
-# Input content as list even when provided as sting
+# Input content as list even when provided as a string
 - name: Post-input SQL scripts to SQL Server
   vars:
     __mssql_sql_content_to_input: "{{

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -404,8 +404,8 @@
               consult the ERRORLOG" in __mssql_set_ha_password.stdout
 
 # Input files var as list even when provided as sting
-# Keep this task after setting password
-- name: Pre-input SQL scripts to SQL Server
+# Keep these 2 tasks after setting password
+- name: Pre-input SQL script files to SQL Server
   vars:
     __mssql_sql_files_to_input: "{{
       mssql_pre_input_sql_file
@@ -414,6 +414,17 @@
       [mssql_pre_input_sql_file] }}"
   include_tasks: input_sql_files.yml
   when: mssql_pre_input_sql_file != []
+
+# Input content as list even when provided as sting
+- name: Pre-input SQL script contents to SQL Server
+  vars:
+    __mssql_sql_content_to_input: "{{
+      mssql_pre_input_sql_content
+      if mssql_pre_input_sql_content | type_debug == 'list'
+      else
+      [mssql_pre_input_sql_content] }}"
+  include_tasks: input_sql_files.yml
+  when: mssql_pre_input_sql_content != []
 
 - name: Set a new edition for MSSQL
   when:
@@ -1197,7 +1208,7 @@
     block: "{{ __lsr_ansible_managed }}"
     insertbefore: BOF
 
-# Keep these 2 tasks at the bottom, they must run at the end of the role
+# Keep these 3 tasks at the bottom, they must run at the end of the role
 - name: Flush handlers prior to inputting post SQL scripts
   meta: flush_handlers
 
@@ -1208,7 +1219,17 @@
       mssql_post_input_sql_file
       if mssql_post_input_sql_file | type_debug == 'list'
       else
-      [mssql_post_input_sql_file]
-    }}"
+      [mssql_post_input_sql_file] }}"
   include_tasks: input_sql_files.yml
   when: mssql_post_input_sql_file != []
+
+# Input content as list even when provided as sting
+- name: Post-input SQL scripts to SQL Server
+  vars:
+    __mssql_sql_content_to_input: "{{
+      mssql_post_input_sql_content
+      if mssql_post_input_sql_content | type_debug == 'list'
+      else
+      [mssql_post_input_sql_content] }}"
+  include_tasks: input_sql_files.yml
+  when: mssql_post_input_sql_content != []

--- a/tasks/sqlcmd_input_content.yml
+++ b/tasks/sqlcmd_input_content.yml
@@ -1,0 +1,25 @@
+---
+- name: Input script content with sqlcmd
+  block:
+    - name: Input script content
+      command: >-
+        {{ __mssql_sqlcmd_login_cmd }} -Q {{ item | quote }} -b
+      register: __mssql_sqlcmd_input
+      changed_when: '"successfully" in __mssql_sqlcmd_input.stdout'
+      # no_log: true
+  always:
+    # Role prints the output if the input succeeds, otherwise Ansible prints the
+    # output from the failed input tasks
+    - name: Print results and clean up after inputting script content
+      when:
+        - >-
+          (mssql_debug | bool) or
+          (__mssql_sqlcmd_input is failed)
+        - __mssql_sqlcmd_loop | length > 0
+      debug:
+        var: __mssql_sqlcmd_loop
+      loop:
+        - "{{ __mssql_sqlcmd_input.stdout_lines }}"
+        - "{{ __mssql_sqlcmd_input.stderr_lines }}"
+      loop_control:
+        loop_var: __mssql_sqlcmd_loop

--- a/tests/tasks/tests_input_sql_file.yml
+++ b/tests/tasks/tests_input_sql_file.yml
@@ -44,6 +44,37 @@
         'The MyUser user already exists, skipping'
         in __mssql_sqlcmd_input.stdout
 
+- name: Set up MSSQL and input sql content with pre_input
+  include_role:
+    name: linux-system-roles.mssql
+  vars:
+    mssql_pre_input_sql_content:
+      - "{{ lookup('template', 'create_example_db.j2') }}"
+      - "{{ lookup('template', 'create_example_db.j2') }}"
+    __mssql_test_db_name: ExampleDB2
+    mssql_password: "p@55w0rD"
+    mssql_edition: Evaluation
+
+- name: Assert the latest script invocation resulted in no changes
+  assert:
+    that: >-
+      'The ExampleDB2 database already exists, skipping' in
+      __mssql_sqlcmd_input.stdout
+
+- name: Set up MSSQL and input sql content with post_input
+  include_role:
+    name: linux-system-roles.mssql
+  vars:
+    mssql_post_input_sql_content:
+      - "{{ lookup('file', 'sql_script.sql') }}"
+    mssql_password: "p@55w0rD"
+
+- name: Assert the latest script invocation resulted in no changes
+  assert:
+    that: >-
+      'The MyLogin login already exists, skipping'
+      in __mssql_sqlcmd_input.stdout
+
 - name: Verify the failure when the mssql_password var is not specified
   block:
     - name: Input the sql file without the mssql_password variable


### PR DESCRIPTION
Enhancement: Add the ability to add SQL scripts as a content directly.

Reason: Previously, users could save SQL script to a file and input it with `mssql_pre_input_sql_file` and `mssql_post_input_sql_file`. Sometimes for shorter scripts it may be an overkill to create a separate file, and it would be easier to provide the script content to the role directly.

Result: With this update, users can provide a T-SQL script directly with `mssql_pre_input_sql_content` and `mssql_post_input_sql_content` variables.
