### PR TITLE
refactor: Deprecate mssql_ad_sql_user_name with mssql_ad_sql_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -1269,7 +1269,7 @@ For more information, see [Join SQL Server on a Linux host to an Active Director
 
 ### Finishing AD Server Configuration
 
-1. After you execute the role to configure AD Server authentication, you must complete one of the following procedures to add AES128 and AES256 kerberos encryption types to the [mssql_ad_sql_user_name](#mssql_ad_sql_user_name) on AD Server.
+1. After you execute the role to configure AD Server authentication, you must complete one of the following procedures to add AES128 and AES256 kerberos encryption types to the [mssql_ad_sql_user](#mssql_ad_sql_user) on AD Server.
 
     * For the RSAT UI users, complete the following steps:
         1. Launch **Active Directory Users and Computers**
@@ -1328,7 +1328,7 @@ For an example playbook, see [Configuring AD integration with a pre-created keyt
 
 
 If you define the `ad_integration_user` variable, the role obtains the kerberos ticket for creating keytab for the `ad_integration_user@ad_integration_realm` user with the `ad_integration_password` password.
-If you don't define the `ad_integration_user` variable, the role obtains the kerberos ticket for `mssql_ad_sql_user_name@ad_integration_realm` user with the `mssql_ad_sql_password` password.
+If you don't define the `ad_integration_user` variable, the role obtains the kerberos ticket for `mssql_ad_sql_user@ad_integration_realm` user with the `mssql_ad_sql_password` password.
 
 Default: `true`
 
@@ -1336,19 +1336,19 @@ Type: `bool`
 
 #### mssql_ad_kerberos_user
 
-Optional, you can use a specific user for obtaining kerberos ticket for creating the `mssql_ad_sql_user_name` user and keytab.
+Optional, you can use a specific user for obtaining kerberos ticket for creating the `mssql_ad_sql_user` user and keytab.
 
 By default, the role uses the following logic:
 
 1. If you define the `ad_integration_user` variable, the role obtains the kerberos ticket for the `ad_integration_user@ad_integration_realm` user with the `ad_integration_password` password.
 
-2. If you don't define the `ad_integration_user` variable, the role obtains the kerberos ticket for `mssql_ad_sql_user_name@ad_integration_realm` user with the `mssql_ad_sql_password` password.
+2. If you don't define the `ad_integration_user` variable, the role obtains the kerberos ticket for `mssql_ad_sql_user@ad_integration_realm` user with the `mssql_ad_sql_password` password.
 
 Default:
 ```yaml
 mssql_ad_kerberos_user: >-
   {{ ad_integration_user if ad_integration_user is defined
-  else mssql_ad_sql_user_name }}
+  else mssql_ad_sql_user }}
 ```
 
 Type: `string`
@@ -1370,7 +1370,7 @@ Type: `string`
 
 Optional: You can use this variable if you don't want the role to generate a keytab file and instead want to pass a pre-created keytab file to mssql-server.
 
-A keytab file must be pre-created on AD Server as per [Tutorial: Use Active Directory authentication with SQL Server on Linux](https://learn.microsoft.com/en-us/sql/linux/sql-server-linux-active-directory-authentication?view=sql-server-ver16). You must ensure that the keytab file is created for the managed node's hostname and for the user provided with the `mssql_ad_sql_user_name` variable.
+A keytab file must be pre-created on AD Server as per [Tutorial: Use Active Directory authentication with SQL Server on Linux](https://learn.microsoft.com/en-us/sql/linux/sql-server-linux-active-directory-authentication?view=sql-server-ver16). You must ensure that the keytab file is created for the managed node's hostname and for the user provided with the `mssql_ad_sql_user` variable.
 
 For an example playbook, see [Configuring AD integration with a pre-created keytab file](#configuring-ad-integration-with-a-pre-created-keytab-file).
 
@@ -1392,7 +1392,7 @@ Default: `false`
 
 Type: `bool`
 
-#### mssql_ad_sql_user_name
+#### mssql_ad_sql_user
 
 User to be created in SQL Server and used for authentication.
 
@@ -1402,7 +1402,7 @@ Type: `string`
 
 #### mssql_ad_sql_password
 
-Password to be set for the [mssql_ad_sql_user_name](#mssql_ad_sql_user_name) user.
+Password to be set for the [mssql_ad_sql_user](#mssql_ad_sql_user) user.
 
 This variable is not required when using [mssql_ad_keytab_file](#mssql_ad_keytab_file).
 
@@ -1414,11 +1414,11 @@ Type: `string`
 
 Optional: You must set `mssql_ad_sql_user_dn` if your AD server stores user account in a custom OU rather than in the `Users` OU.
 
-AD distinguished name to create the [mssql_ad_sql_user_name](#mssql_ad_sql_user_name) at.
+AD distinguished name to create the [mssql_ad_sql_user](#mssql_ad_sql_user) at.
 
 By default, the role builds `mssql_ad_sql_user_dn` the following way:
 
-1. `CN={{ mssql_ad_sql_user_name }},` - name of the user created in AD
+1. `CN={{ mssql_ad_sql_user }},` - name of the user created in AD
 2. `CN=Users,` - the `Users` OU where AD stores users by default
 3. `DC=<subdomain1>,DC=<subdomain2>,DC=<subdomainN>,` - all subdomain portions of the AD domain name provided with the `ad_integration_realm` variable
 4. `DC=<TLD>` - top level domain
@@ -1428,7 +1428,7 @@ For example: `CN=sqluser,CN=Users,DC=DOMAIN,DC=COM`.
 Default:
 ```yaml
 mssql_ad_sql_user_dn: >-
-  CN={{ mssql_ad_sql_user_name }},
+  CN={{ mssql_ad_sql_user }},
   CN=Users,
   {{ ad_integration_realm.split(".")
   | map("regex_replace","^","DC=")
@@ -1453,7 +1453,7 @@ Type: `string`
     mssql_edition: Evaluation
     mssql_manage_firewall: true
     mssql_ad_configure: true
-    mssql_ad_sql_user_name: sqluser
+    mssql_ad_sql_user: sqluser
     mssql_ad_sql_password: "p@55w0rD1"
     ad_integration_realm: domain.com
     ad_integration_user: Administrator
@@ -1497,7 +1497,7 @@ If you received a pre-created keytab file and want the role to use it, set varia
     mssql_ad_configure: true
     mssql_ad_keytab_file: /path/to/file
     mssql_ad_keytab_remote_src: false
-    mssql_ad_sql_user_name: sqluser
+    mssql_ad_sql_user: sqluser
     ad_integration_realm: domain.com
     ad_integration_user: Administrator
     ad_integration_manage_dns: true
@@ -1538,7 +1538,7 @@ You must join managed host to AD Server yourself prior to running this playbook.
     mssql_manage_firewall: true
     mssql_ad_configure: true
     mssql_ad_join: false
-    mssql_ad_sql_user_name: sqluser
+    mssql_ad_sql_user: sqluser
     mssql_ad_kerberos_user: user_administrator
     mssql_ad_kerberos_password: Secret123
     ad_integration_realm: domain.com

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,11 +57,11 @@ mssql_ha_cluster_run_role: false
 
 mssql_ad_configure: false
 mssql_ad_join: true
-mssql_ad_sql_user_name: null
+mssql_ad_sql_user: null
 mssql_ad_sql_password: null
-# Default to CN={{ mssql_ad_sql_user_name }},CN=Users,DC=DOMAIN,DC=SUBDOMAIN...
+# Default to CN={{ mssql_ad_sql_user }},CN=Users,DC=DOMAIN,DC=SUBDOMAIN...
 mssql_ad_sql_user_dn: >-
-  CN={{ mssql_ad_sql_user_name }},
+  CN={{ mssql_ad_sql_user }},
   CN=Users,
   {{ ad_integration_realm.split(".")
   | map("regex_replace", "^", "DC=")
@@ -70,7 +70,7 @@ mssql_ad_keytab_file: null
 mssql_ad_keytab_remote_src: false
 mssql_ad_kerberos_user: >-
   {{ ad_integration_user if ad_integration_user is defined
-  else mssql_ad_sql_user_name }}
+  else mssql_ad_sql_user }}
 mssql_ad_kerberos_password: >-
   {{ ad_integration_password if ad_integration_user is defined
   else mssql_ad_sql_password }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,6 +38,20 @@
       set_fact:
         mssql_ha_endpoint_port: "{{ mssql_ha_listener_port }}"
 
+- name: Link the deprecated mssql_ad_sql_user_name fact
+  when: mssql_ad_sql_user_name is defined
+  block:
+    - name: Print that the mssql_ad_sql_user_name variable is deprecated
+      debug:
+        msg: >-
+          The mssql_ad_sql_user_name variable is deprecated and will be removed
+          in a future version. Edit your playbook to use
+          mssql_ad_sql_user variable instead.
+
+    - name: Link the deprecated mssql_ad_sql_user_name fact
+      set_fact:
+        mssql_ad_sql_user: "{{ mssql_ad_sql_user_name }}"
+
 - name: Verify that the user accepts EULA variables
   assert:
     that:
@@ -721,19 +735,19 @@
           changed_when: true
 
         # Do not fail if account does not exist
-        - name: Check if AD user exists {{ mssql_ad_sql_user_name }}
+        - name: Check if AD user exists {{ mssql_ad_sql_user }}
           command: >-
             adutil account exists
-            --name {{ mssql_ad_sql_user_name }}
+            --name {{ mssql_ad_sql_user }}
             --accept-eula
           register: __mssql_adutil_account_exists
           changed_when: false
           failed_when: false
 
-        - name: In AD server create user {{ mssql_ad_sql_user_name }}
+        - name: In AD server create user {{ mssql_ad_sql_user }}
           command: >-
             adutil user create
-            --name {{ mssql_ad_sql_user_name }}
+            --name {{ mssql_ad_sql_user }}
             --password {{ mssql_ad_sql_password | quote }}
             --distname {{ mssql_ad_sql_user_dn | quote }}
             --debug
@@ -742,15 +756,15 @@
           no_log: true
           changed_when: true
 
-        - name: Get SPNs for the principal {{ mssql_ad_sql_user_name }}
-          command: adutil spn show --name {{ mssql_ad_sql_user_name }}
+        - name: Get SPNs for the principal {{ mssql_ad_sql_user }}
+          command: adutil spn show --name {{ mssql_ad_sql_user }}
           register: __mssql_adutil_spn_show
           changed_when: false
 
-        - name: Register SPNs to the principal {{ mssql_ad_sql_user_name }}
+        - name: Register SPNs to the principal {{ mssql_ad_sql_user }}
           command: >-
             adutil spn addauto
-            --name {{ mssql_ad_sql_user_name }}
+            --name {{ mssql_ad_sql_user }}
             --spn-service MSSQLSvc
             --spn-host {{ ansible_fqdn }}
             --spn-port {{ mssql_tcp_port }}
@@ -765,7 +779,7 @@
             in __mssql_adutil_spn_show.stdout
 
         - name: Get kvno of the SPN host
-          command: adutil account kvno {{ mssql_ad_sql_user_name }}
+          command: adutil account kvno {{ mssql_ad_sql_user }}
           register: __mssql_kvno
           changed_when: false
 
@@ -811,16 +825,16 @@
             adutil keytab create
             --password {{ mssql_ad_sql_password | quote }}
             --path {{ __mssql_keytab_path }}
-            --principal {{ mssql_ad_sql_user_name }}
+            --principal {{ mssql_ad_sql_user }}
             --kvno {{ __mssql_kvno.stdout }}
             --enctype aes256-cts-hmac-sha1-96,aes128-cts-hmac-sha1-96
           when:
             - >-
-              not __mssql_kvno.stdout ~ " " ~ mssql_ad_sql_user_name ~ "@"
+              not __mssql_kvno.stdout ~ " " ~ mssql_ad_sql_user ~ "@"
               ~ ad_integration_realm | upper ~ " (aes256-cts-hmac-sha1-96)"
               in __mssql_keytab_properties.stdout | d()
             - >-
-              not __mssql_kvno.stdout ~ " " ~ mssql_ad_sql_user_name ~ "@"
+              not __mssql_kvno.stdout ~ " " ~ mssql_ad_sql_user ~ "@"
               ~ ad_integration_realm | upper ~ " (aes128-cts-hmac-sha1-96)"
               in __mssql_keytab_properties.stdout | d()
           notify: Restart the mssql-server service
@@ -855,7 +869,7 @@
       include_tasks: mssql_conf_setting.yml
       vars:
         __mssql_conf_setting: network privilegedadaccount
-        __mssql_conf_setting_value: "{{ mssql_ad_sql_user_name }}"
+        __mssql_conf_setting_value: "{{ mssql_ad_sql_user }}"
   rescue:
     - name: Print output of failed task
       when: item | length > 0

--- a/tests/playbooks/tests_ad_integration.yml
+++ b/tests/playbooks/tests_ad_integration.yml
@@ -31,7 +31,7 @@
     mssql_manage_firewall: true
     mssql_debug: true
     mssql_ad_configure: true
-    mssql_ad_sql_user_name: sqluser
+    mssql_ad_sql_user: sqluser
     mssql_ad_sql_password: "p@55w0rD1"
     ad_integration_realm: domain.com
     ad_integration_user: Administrator
@@ -63,18 +63,18 @@
       include_role:
         name: linux-system-roles.mssql
 
-    - name: Get KerberosEncryptionType of user {{ mssql_ad_sql_user_name }}
+    - name: Get KerberosEncryptionType of user {{ mssql_ad_sql_user }}
       ansible.windows.win_shell: >-
-        Get-ADUser -Identity {{ mssql_ad_sql_user_name }}
+        Get-ADUser -Identity {{ mssql_ad_sql_user }}
         -Properties *
         | Format-Table Name,KerberosEncryptionType -A
       register: __mssql_sql_username_enc_type
       changed_when: false
       delegate_to: ad
 
-    - name: Set AES128,AES256 encryption type for {{ mssql_ad_sql_user_name }}
+    - name: Set AES128,AES256 encryption type for {{ mssql_ad_sql_user }}
       ansible.windows.win_shell: >-
-        Set-ADUser -Identity {{ mssql_ad_sql_user_name }}
+        Set-ADUser -Identity {{ mssql_ad_sql_user }}
         -KerberosEncryptionType AES128,AES256
       when: "not 'AES128, AES256' in __mssql_sql_username_enc_type.stdout"
       delegate_to: ad

--- a/tests/tasks/verify_ad_auth.yml
+++ b/tests/tasks/verify_ad_auth.yml
@@ -43,7 +43,7 @@
         set -euo pipefail;
         sshpass -p {{ mssql_ad_sql_password | quote }}
         ssh -o StrictHostKeyChecking=no
-        -l {{ mssql_ad_sql_user_name }}@{{ ad_integration_realm }}
+        -l {{ mssql_ad_sql_user }}@{{ ad_integration_realm }}
         {{ ansible_fqdn }}
         "echo {{ ad_integration_password | quote }}
         | kinit {{ __mssql_kinit_user }} &&


### PR DESCRIPTION
Enhancement: Deprecate the `mssql_ad_sql_user_name` variable, instead use the `mssql_ad_sql_user` variable for consistency with the `ad_integration_user` variable in the ad_integration system role and with other system roles. 

Reason: Generally, system roles use the `_user` variable and not the `user_name`.

Result: The previously used `mssql_ad_sql_user_name` is marked as deprecated, when one uses this variable, the role informs that it is deprecated and will be removed in a future release, still the variable works the same way. Documentation now uses the `mssql_ad_sql_user` variable. 