### PR TITLE
fix: Remove unnecessary variable requirements for read-scale clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,7 +818,25 @@ Default: `[]`
 
 Type: `list`
 
+#### mssql_ha_virtual_ip
+
+Only applicable when you set `mssql_ha_ag_cluster_type` to `external`.
+
+The virtual IP address to be configured for the SQL cluster.
+
+The role creates an availability group listener using the following values:
+
+* The port provided with the `mssql_tcp_port` variable,
+* The IP address provided with the `mssql_ha_virtual_ip` variable
+* The `255.255.255.0` subnet mask
+
+Default: `null`
+
+Type: `string`
+
 #### mssql_ha_login
+
+Only applicable when you set `mssql_ha_ag_cluster_type` to `external`.
 
 The user created for Pacemaker in SQL Server.
 This user is used by the SQL Server Pacemaker resource agent to connect to SQL Server to perform regular database health checks and manage state transitions from replica to primary when needed.
@@ -829,6 +847,8 @@ Type: `string`
 
 #### mssql_ha_login_password
 
+Only applicable when you set `mssql_ha_ag_cluster_type` to `external`.
+
 The password for the mssql_ha_login user in SQL Server.
 
 Default: `null`
@@ -836,6 +856,8 @@ Default: `null`
 Type: `string`
 
 #### mssql_ha_cluster_run_role
+
+Only applicable when you set `mssql_ha_ag_cluster_type` to `external`.
 
 Whether to run the `fedora.linux_system_roles.ha_cluster` role from this role.
 
@@ -854,22 +876,6 @@ If you do not want the `microsoft.sql.server` to run the `fedora.linux_system_ro
 Default: `false`
 
 Type: `bool`
-
-#### mssql_ha_virtual_ip
-
-Only applicable when you set `mssql_ha_ag_cluster_type` to `external`.
-
-The virtual IP address to be configured for the SQL cluster.
-
-The role creates an availability group listener using the following values:
-
-* The port provided with the `mssql_tcp_port` variable,
-* The IP address provided with the `mssql_ha_virtual_ip` variable
-* The `255.255.255.0` subnet mask
-
-Default: `null`
-
-Type: `string`
 
 ### Always On Availability Group Example Playbooks
 
@@ -939,8 +945,6 @@ In this case the role does not configure Pacemaker.
     mssql_ha_db_names:
       - ExampleDB1
       - ExampleDB2
-    mssql_ha_login: ExamleLogin
-    mssql_ha_login_password: "p@55w0rD3"
   roles:
     - microsoft.sql.server
 ```

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1017,6 +1017,7 @@
             name: "{{ __mssql_server_ha_packages }}"
             state: "{{ mssql_ha_configure | ternary('present', 'absent') }}"
           register: __mssql_server_ha_packages_install
+          when: mssql_ha_ag_cluster_type | lower == 'external'
 
         - name: Enable the hadrenabled setting
           include_tasks: mssql_conf_setting.yml
@@ -1031,7 +1032,7 @@
             state: restarted
           # noqa no-handler
           when: (__mssql_conf_set is changed) or
-            (__mssql_server_ha_packages_install is changed)
+            (__mssql_server_ha_packages_install | d() is changed)
 
         - name: Remove certificates
           when: mssql_ha_reset_cert | bool
@@ -1064,8 +1065,14 @@
               - create_and_back_up_cert.j2
               - enable_alwayson.j2
               - configure_endpoint.j2
+          include_tasks: input_sql_files.yml
+
+        - name: Create login for HA on in SQL Server
+          vars:
+            __mssql_sql_files_to_input:
               - create_ha_login.j2
           include_tasks: input_sql_files.yml
+          when: mssql_ha_ag_cluster_type | lower == 'external'
 
         # changed_when: false because role removes cert files after using them
         - name: Fetch certificate files from the primary to the control node
@@ -1115,14 +1122,32 @@
         # __mssql_single_node_test is to skip __mssql_ha_is_primary check when
         # testing against a single node where SQL Always On cluster breaks and
         # does not report the single node as primary because it needs more nodes
-        - name: Configure ag, grant permissions to login, replicate DBs
+        - name: Configure ag
           when: >-
             __mssql_ha_is_primary | bool
             or __mssql_single_node_test | d(false) | bool
           vars:
             __mssql_sql_files_to_input:
               - configure_ag.j2
+              - replicate_db.j2
+          include_tasks: input_sql_files.yml
+
+        - name: Grant permissions to HA login
+          when: >-
+            - __mssql_ha_is_primary | bool
+              or __mssql_single_node_test | d(false) | bool
+            - mssql_ha_ag_cluster_type | lower == 'external'
+          vars:
+            __mssql_sql_files_to_input:
               - grant_permissions_to_ha_login.j2
+          include_tasks: input_sql_files.yml
+
+        - name: Replicate DBs
+          when: >-
+            __mssql_ha_is_primary | bool
+            or __mssql_single_node_test | d(false) | bool
+          vars:
+            __mssql_sql_files_to_input:
               - replicate_db.j2
           include_tasks: input_sql_files.yml
 
@@ -1136,6 +1161,7 @@
       when:
         - not __mssql_ha_is_primary
         - mssql_ha_replica_type == 'primary'
+        - mssql_ha_ag_cluster_type | lower == 'external'
 
     - name: Configure availability group on not primary replicas
       when: mssql_ha_replica_type in __mssql_ha_replica_types_secondary
@@ -1158,6 +1184,7 @@
             name: "{{ __mssql_server_ha_packages }}"
             state: "{{ mssql_ha_configure | ternary('present', 'absent') }}"
           register: __mssql_server_ha_packages_install
+          when: mssql_ha_ag_cluster_type | lower == 'external'
 
         - name: Enable the hadrenabled setting
           include_tasks: mssql_conf_setting.yml
@@ -1172,7 +1199,7 @@
             state: restarted
           # noqa no-handler
           when: (__mssql_conf_set is changed) or
-            (__mssql_server_ha_packages_install is changed)
+            (__mssql_server_ha_packages_install | d() is changed)
           register: __mssql_replica_restarted
 
         - name: Remove certificate from SQL Server
@@ -1201,10 +1228,27 @@
               - create_master_key_encryption.j2
               - restore_cert.j2
               - configure_endpoint.j2
+          include_tasks: input_sql_files.yml
+
+        - name: Configure SQL entities on not primary replicas
+          vars:
+            __mssql_sql_files_to_input:
               - create_ha_login.j2
+          include_tasks: input_sql_files.yml
+          when: mssql_ha_ag_cluster_type | lower == 'external'
+
+        - name: Configure SQL entities on not primary replicas
+          vars:
+            __mssql_sql_files_to_input:
               - join_to_ag.j2
+          include_tasks: input_sql_files.yml
+
+        - name: Configure SQL entities on not primary replicas
+          vars:
+            __mssql_sql_files_to_input:
               - grant_permissions_to_ha_login.j2
           include_tasks: input_sql_files.yml
+          when: mssql_ha_ag_cluster_type | lower == 'external'
       always:
         # changed_when: false because this task removes remnants of cert files
         - name: Remove certificate and private key from the control node


### PR DESCRIPTION
Enhancement: Remove unnecessary variable requirements for read-scale clusters

Reason: Read-scale clusters do not require creating users for Pacemaker and installing the `mssql-server-ha` package.

Result: This remove a requirement for unnecessary variables when running a read-scale cluster and requirement to install the mssql-server-ha, which depends on packages from HA repository.