### PR TITLE
chore: Use GA repository for RHEL 9

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 ---
 __mssql_server_repository: >-
-  https://packages.microsoft.com/rhel/9/mssql-server-preview/
+  https://packages.microsoft.com/rhel/9/mssql-server-{{ mssql_version | int }}/
 __mssql_client_repository: >-
   https://packages.microsoft.com/rhel/9/prod/
 __mssql_supported_versions:


### PR DESCRIPTION
Enhancement: Use GA repository for RHEL 9

Reason: Microsoft created a GA repository for RHEL 9 instead of the tech preview repository

Result: On RHEL 9, mssql-server is taken from the GA repository instead of the preview repository.
