### PR TITLE
feat: Add mssql_ha_prep_for_pacemaker for configuring HA solution other than Pacemaker

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,9 +50,11 @@ mssql_ha_reset_cert: false
 mssql_ha_endpoint_name: null
 mssql_ha_ag_name: null
 mssql_ha_db_names: []
+
+mssql_ha_prep_for_pacemaker: "{{ mssql_ha_ag_cluster_type | lower != 'none' }}"
+mssql_ha_virtual_ip: null
 mssql_ha_login: null
 mssql_ha_login_password: null
-mssql_ha_virtual_ip: null
 mssql_ha_cluster_run_role: false
 
 mssql_ad_configure: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1024,9 +1024,7 @@
             name: "{{ __mssql_server_ha_packages }}"
             state: "{{ mssql_ha_configure | ternary('present', 'absent') }}"
           register: __mssql_server_ha_packages_install
-          when:
-            - mssql_ha_ag_cluster_type | lower == 'external'
-            - mssql_ha_prep_for_pacemaker | bool
+          when: mssql_ha_prep_for_pacemaker | bool
 
         - name: Enable the hadrenabled setting
           include_tasks: mssql_conf_setting.yml
@@ -1074,9 +1072,7 @@
             __mssql_sql_files_to_input:
               - create_ha_login.j2
           include_tasks: input_sql_files.yml
-          when:
-            - mssql_ha_ag_cluster_type | lower == 'external'
-            - mssql_ha_prep_for_pacemaker | bool
+          when: mssql_ha_prep_for_pacemaker | bool
 
         # changed_when: false because role removes cert files after using them
         - name: Fetch certificate files from the primary to the control node
@@ -1140,7 +1136,6 @@
           when:
             - __mssql_ha_is_primary | bool
               or __mssql_single_node_test | d(false) | bool
-            - mssql_ha_ag_cluster_type | lower == 'external'
             - mssql_ha_prep_for_pacemaker | bool
           vars:
             __mssql_sql_files_to_input:
@@ -1166,7 +1161,6 @@
       when:
         - not __mssql_ha_is_primary
         - mssql_ha_replica_type == 'primary'
-        - mssql_ha_ag_cluster_type | lower == 'external'
         - mssql_ha_prep_for_pacemaker | bool
 
     - name: Configure availability group on not primary replicas
@@ -1190,9 +1184,7 @@
             name: "{{ __mssql_server_ha_packages }}"
             state: "{{ mssql_ha_configure | ternary('present', 'absent') }}"
           register: __mssql_server_ha_packages_install
-          when:
-            - mssql_ha_ag_cluster_type | lower == 'external'
-            - mssql_ha_prep_for_pacemaker | bool
+          when: mssql_ha_prep_for_pacemaker | bool
 
         - name: Enable the hadrenabled setting
           include_tasks: mssql_conf_setting.yml
@@ -1243,9 +1235,7 @@
             __mssql_sql_files_to_input:
               - create_ha_login.j2
           include_tasks: input_sql_files.yml
-          when:
-            - mssql_ha_ag_cluster_type | lower == 'external'
-            - mssql_ha_prep_for_pacemaker | bool
+          when: mssql_ha_prep_for_pacemaker | bool
 
         - name: Join to availability group
           vars:
@@ -1258,9 +1248,7 @@
             __mssql_sql_files_to_input:
               - grant_permissions_to_ha_login.j2
           include_tasks: input_sql_files.yml
-          when:
-            - mssql_ha_ag_cluster_type | lower == 'external'
-            - mssql_ha_prep_for_pacemaker | bool
+          when: mssql_ha_prep_for_pacemaker | bool
       always:
         # changed_when: false because this task removes remnants of cert files
         - name: Remove certificate and private key from the control node
@@ -1274,9 +1262,7 @@
           changed_when: false
 
     - name: Configure pacemaker
-      when:
-        - mssql_ha_ag_cluster_type | lower == 'external'
-        - mssql_ha_prep_for_pacemaker | bool
+      when: mssql_ha_prep_for_pacemaker | bool
       block:
         - name: Save credentials for the SQL Server login {{ mssql_ha_login }}
           copy:
@@ -1302,7 +1288,6 @@
           - configure_listener.j2
       include_tasks: input_sql_files.yml
       when:
-        - mssql_ha_ag_cluster_type | lower == 'external'
         - __mssql_ha_is_primary | bool
         - mssql_ha_prep_for_pacemaker | bool
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1039,7 +1039,7 @@
             state: restarted
           # noqa no-handler
           when: (__mssql_conf_set is changed) or
-            (__mssql_server_ha_packages_install | d() is changed)
+            (__mssql_server_ha_packages_install | d({}) is changed)
 
         - name: Remove certificates
           when: mssql_ha_reset_cert | bool
@@ -1129,7 +1129,6 @@
           vars:
             __mssql_sql_files_to_input:
               - configure_ag.j2
-              - replicate_db.j2
           include_tasks: input_sql_files.yml
 
         - name: Grant permissions to HA login
@@ -1199,7 +1198,7 @@
             state: restarted
           # noqa no-handler
           when: (__mssql_conf_set is changed) or
-            (__mssql_server_ha_packages_install | d() is changed)
+            (__mssql_server_ha_packages_install | d({}) is changed)
           register: __mssql_replica_restarted
 
         - name: Remove certificate from SQL Server

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -84,15 +84,26 @@
 - name: Verify that 'mssql_ha_replica_type = primary' is provided once
   assert:
     that: ansible_play_hosts_all |
-        map('extract', hostvars, 'mssql_ha_replica_type') |
-        select('match', '^primary$') |
-        list |
-        length == 1
+      map('extract', hostvars, 'mssql_ha_replica_type') |
+      select('match', '^primary$') |
+      list |
+      length == 1
     fail_msg: >-
       You must set the mssql_ha_replica_type variable to 'primary' for one of
       your managed nodes
   run_once: true
   when: mssql_ha_configure | bool
+
+- name: Verify that mssql_ha_prep_for_pacemaker is provided correctly
+  when:
+    - mssql_ha_ag_cluster_type | lower == 'none'
+    - (mssql_ha_prep_for_pacemaker | bool)
+      or (mssql_ha_cluster_run_role | bool)
+  fail:
+    msg: >-
+      You set mssql_ha_ag_cluster_type to none, in this case you must not set
+      mssql_ha_prep_for_pacemaker and mssql_ha_cluster_run_role to true because
+      read-scale clusters do not require Pacemaker
 
 - name: Verify that selinux variables are used on supported platforms
   when:
@@ -1013,7 +1024,9 @@
             name: "{{ __mssql_server_ha_packages }}"
             state: "{{ mssql_ha_configure | ternary('present', 'absent') }}"
           register: __mssql_server_ha_packages_install
-          when: mssql_ha_ag_cluster_type | lower == 'external'
+          when:
+            - mssql_ha_ag_cluster_type | lower == 'external'
+            - mssql_ha_prep_for_pacemaker | bool
 
         - name: Enable the hadrenabled setting
           include_tasks: mssql_conf_setting.yml
@@ -1061,7 +1074,9 @@
             __mssql_sql_files_to_input:
               - create_ha_login.j2
           include_tasks: input_sql_files.yml
-          when: mssql_ha_ag_cluster_type | lower == 'external'
+          when:
+            - mssql_ha_ag_cluster_type | lower == 'external'
+            - mssql_ha_prep_for_pacemaker | bool
 
         # changed_when: false because role removes cert files after using them
         - name: Fetch certificate files from the primary to the control node
@@ -1122,10 +1137,11 @@
           include_tasks: input_sql_files.yml
 
         - name: Grant permissions to HA login
-          when: >-
+          when:
             - __mssql_ha_is_primary | bool
               or __mssql_single_node_test | d(false) | bool
             - mssql_ha_ag_cluster_type | lower == 'external'
+            - mssql_ha_prep_for_pacemaker | bool
           vars:
             __mssql_sql_files_to_input:
               - grant_permissions_to_ha_login.j2
@@ -1142,7 +1158,7 @@
 
     # In the case of fail over when primary is moved grant permission task above
     # is not run on primary above hence we need to run it separately
-    - name: Grant permissions to ha login
+    - name: Grant permissions to HA login
       vars:
         __mssql_sql_files_to_input:
           - grant_permissions_to_ha_login.j2
@@ -1151,6 +1167,7 @@
         - not __mssql_ha_is_primary
         - mssql_ha_replica_type == 'primary'
         - mssql_ha_ag_cluster_type | lower == 'external'
+        - mssql_ha_prep_for_pacemaker | bool
 
     - name: Configure availability group on not primary replicas
       when: mssql_ha_replica_type in __mssql_ha_replica_types_secondary
@@ -1173,7 +1190,9 @@
             name: "{{ __mssql_server_ha_packages }}"
             state: "{{ mssql_ha_configure | ternary('present', 'absent') }}"
           register: __mssql_server_ha_packages_install
-          when: mssql_ha_ag_cluster_type | lower == 'external'
+          when:
+            - mssql_ha_ag_cluster_type | lower == 'external'
+            - mssql_ha_prep_for_pacemaker | bool
 
         - name: Enable the hadrenabled setting
           include_tasks: mssql_conf_setting.yml
@@ -1219,25 +1238,29 @@
               - configure_endpoint.j2
           include_tasks: input_sql_files.yml
 
-        - name: Configure SQL entities on not primary replicas
+        - name: Create HA login
           vars:
             __mssql_sql_files_to_input:
               - create_ha_login.j2
           include_tasks: input_sql_files.yml
-          when: mssql_ha_ag_cluster_type | lower == 'external'
+          when:
+            - mssql_ha_ag_cluster_type | lower == 'external'
+            - mssql_ha_prep_for_pacemaker | bool
 
-        - name: Configure SQL entities on not primary replicas
+        - name: Join to availability group
           vars:
             __mssql_sql_files_to_input:
               - join_to_ag.j2
           include_tasks: input_sql_files.yml
 
-        - name: Configure SQL entities on not primary replicas
+        - name: Grant permissions to HA login
           vars:
             __mssql_sql_files_to_input:
               - grant_permissions_to_ha_login.j2
           include_tasks: input_sql_files.yml
-          when: mssql_ha_ag_cluster_type | lower == 'external'
+          when:
+            - mssql_ha_ag_cluster_type | lower == 'external'
+            - mssql_ha_prep_for_pacemaker | bool
       always:
         # changed_when: false because this task removes remnants of cert files
         - name: Remove certificate and private key from the control node
@@ -1251,7 +1274,9 @@
           changed_when: false
 
     - name: Configure pacemaker
-      when: mssql_ha_ag_cluster_type | lower == 'external'
+      when:
+        - mssql_ha_ag_cluster_type | lower == 'external'
+        - mssql_ha_prep_for_pacemaker | bool
       block:
         - name: Save credentials for the SQL Server login {{ mssql_ha_login }}
           copy:
@@ -1279,6 +1304,7 @@
       when:
         - mssql_ha_ag_cluster_type | lower == 'external'
         - __mssql_ha_is_primary | bool
+        - mssql_ha_prep_for_pacemaker | bool
 
 - name: Ensure the ansible_managed header in {{ __mssql_conf_path }}
   vars:

--- a/tests/tests_configure_ha_cluster_external.yml
+++ b/tests/tests_configure_ha_cluster_external.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Verify the role on the primary node
+- name: Verify HA functionality with external clusters and templates
   hosts: all
   vars:
     __mssql_single_node_test: "{{ ansible_play_hosts_all | length == 1 }}"
@@ -28,11 +28,13 @@
     mssql_ha_db_names:
       - ExampleDB1
       - ExampleDB2
+    mssql_ha_ag_cluster_type: external
     mssql_ha_login: ExampleLogin
     mssql_ha_login_password: "p@55w0rD3"
     mssql_ha_virtual_ip: 192.168.122.148
     # ha_cluster doesn't support running against a single host
-    mssql_ha_cluster_run_role: "{{ ansible_play_hosts_all | length > 1 }}"
+    mssql_ha_cluster_run_role: "{{
+      ansible_play_hosts_all | length > 1 }}"
     ha_cluster_cluster_name: "{{ mssql_ha_ag_name }}"
     ha_cluster_hacluster_password: "p@55w0rD4"
     ha_cluster_sbd_enabled: true
@@ -155,18 +157,6 @@
               - create_ExampleDB2.sql
           when: mssql_ha_replica_type == 'primary'
 
-        # Only when witness node is not specified
-        - name: Run on all hosts to configure read-scale cluster
-          include_role:
-            name: linux-system-roles.mssql
-          vars:
-            mssql_ha_ag_cluster_type: none
-          when: ansible_play_hosts_all |
-            map('extract', hostvars, 'mssql_ha_replica_type') |
-            select('match', '^witness$') |
-            list |
-            length == 0
-
         - name: Set up test environment for the ha_cluster role
           include_role:
             name: fedora.linux_system_roles.ha_cluster
@@ -175,8 +165,6 @@
         - name: Run on all hosts to configure HA cluster
           include_role:
             name: linux-system-roles.mssql
-          vars:
-            mssql_ha_ag_cluster_type: external
 
         - name: Assert that pcs runs properly when testing against >3 nodes
           when: ansible_play_hosts_all | length >= 3
@@ -985,4 +973,3 @@
       always:
         - name: Clean up after the role invocation
           include_tasks: tasks/cleanup.yml
-          when: ansible_play_hosts_all | length == 1

--- a/tests/tests_configure_ha_cluster_external.yml
+++ b/tests/tests_configure_ha_cluster_external.yml
@@ -156,6 +156,21 @@
               - create_ExampleDB2.sql
           when: mssql_ha_replica_type == 'primary'
 
+        # Only when witness node is not specified
+        - name: Run on all hosts to configure read-scale cluster
+          include_role:
+            name: linux-system-roles.mssql
+          vars:
+            mssql_ha_ag_cluster_type: none
+            mssql_ha_login: null
+            mssql_ha_login_password: null
+            mssql_ha_virtual_ip: null
+          when: ansible_play_hosts_all |
+            map('extract', hostvars, 'mssql_ha_replica_type') |
+            select('match', '^witness$') |
+            list |
+            length == 0
+
         - name: Set up test environment for the ha_cluster role
           include_role:
             name: fedora.linux_system_roles.ha_cluster

--- a/tests/tests_configure_ha_cluster_external.yml
+++ b/tests/tests_configure_ha_cluster_external.yml
@@ -33,8 +33,7 @@
     mssql_ha_login_password: "p@55w0rD3"
     mssql_ha_virtual_ip: 192.168.122.148
     # ha_cluster doesn't support running against a single host
-    mssql_ha_cluster_run_role: "{{
-      ansible_play_hosts_all | length > 1 }}"
+    mssql_ha_cluster_run_role: "{{ ansible_play_hosts_all | length > 1 }}"
     ha_cluster_cluster_name: "{{ mssql_ha_ag_name }}"
     ha_cluster_hacluster_password: "p@55w0rD4"
     ha_cluster_sbd_enabled: true

--- a/tests/tests_configure_ha_cluster_read_scale.yml
+++ b/tests/tests_configure_ha_cluster_read_scale.yml
@@ -31,6 +31,35 @@
   tasks:
     - name: Run test in a block to clean up in always
       block:
+        - name: Verify that by default the role fails on EL < 8
+          when:
+            - ansible_distribution in ['CentOS', 'RedHat']
+            - ansible_distribution_version is version('8', '<')
+          block:
+            - name: Run the role
+              vars:
+                mssql_ha_configure: true
+              include_role:
+                name: linux-system-roles.mssql
+
+            - name: Unreachable task
+              fail:
+                msg: The above task must fail
+          rescue:
+            - name: Assert that the role failed with EL 7 not supported
+              assert:
+                that: >-
+                  'mssql_ha_configure=true does not support running against EL 7
+                  hosts' in ansible_failed_result.msg
+          always:
+            - name: Clean up after the role invocation
+              include_tasks: tasks/cleanup.yml
+              when: ansible_play_hosts_all | length == 1
+
+            # Putting end_host into a rescue block results in a failed task
+            - name: End EL 7 host
+              meta: end_host
+
         - name: Set the mssql_ha_replica_type fact to appear in hostvars
           set_fact:
             mssql_ha_replica_type: primary

--- a/tests/tests_configure_ha_cluster_read_scale.yml
+++ b/tests/tests_configure_ha_cluster_read_scale.yml
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Verify HA functionality with read-scale clusters
+  hosts: all
+  vars:
+    mssql_debug: true
+    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
+    mssql_accept_microsoft_sql_server_standard_eula: true
+    mssql_password: "p@55w0rD"
+    mssql_edition: Evaluation
+    mssql_version: 2022
+    mssql_manage_firewall: true
+    __mssql_test_confined_supported: "{{
+      (ansible_distribution in ['CentOS', 'RedHat']) and
+      (ansible_distribution_major_version is version('9', '>=')) }}"
+    mssql_manage_selinux: "{{ __mssql_test_confined_supported }}"
+    mssql_run_selinux_confined: "{{ __mssql_test_confined_supported }}"
+    mssql_ha_configure: true
+    mssql_ha_endpoint_port: 5022
+    mssql_ha_cert_name: ExampleCert
+    mssql_ha_master_key_password: "p@55w0rD1"
+    mssql_ha_private_key_password: "p@55w0rD2"
+    mssql_ha_reset_cert: false
+    mssql_ha_endpoint_name: Example_Endpoint
+    mssql_ha_ag_name: ExampleAG
+    mssql_ha_db_names:
+      - ExampleDB1
+      - ExampleDB2
+    mssql_ha_ag_cluster_type: none
+  tasks:
+    - name: Run test in a block to clean up in always
+      block:
+        - name: Set the mssql_ha_replica_type fact to appear in hostvars
+          set_fact:
+            mssql_ha_replica_type: primary
+          when:
+            - ansible_play_hosts_all | length == 1
+            - mssql_ha_replica_type is not defined
+
+        - name: Set facts to create test DBs on primary as a pre task
+          set_fact:
+            mssql_pre_input_sql_file:
+              - create_ExampleDB1.sql
+              - create_ExampleDB2.sql
+          when: mssql_ha_replica_type == 'primary'
+
+        # Only when witness node is not specified
+        - name: Run on all hosts to configure read-scale cluster
+          include_role:
+            name: linux-system-roles.mssql
+
+        - name: Verify that the database exists on the secondary servers
+          vars:
+            __mssql_sql_content_to_input:
+              - |-
+                IF EXISTS(
+                  SELECT name
+                  FROM sys.databases
+                  WHERE name = 'ExampleDB1'
+                )
+                BEGIN
+                  PRINT 'SUCCESS, The database ExampleDB1 exists'
+                END
+                ELSE
+                BEGIN
+                  PRINT 'FAIL, The database ExampleDB1 exists'
+                END
+          include_role:
+            name: linux-system-roles.mssql
+            tasks_from: input_sql_files.yml
+
+        - name: Assert that the template reported changed state
+          assert:
+            that: >-
+              "SUCCESS, The database ExampleDB1 exists" in
+              __mssql_sqlcmd_input.stdout
+      always:
+        - name: Clean up after the role invocation
+          include_tasks: tasks/cleanup.yml


### PR DESCRIPTION
Enhancement: Add the `mssql_ha_prep_for_pacemaker` variable to configure SQL Server for Pacemaker.

Reason: Previously, the role did not have a variable to control whether to configure SQL Server for Pacemaker. Some users require to not configure for Pacemaker to use some custom HA solution.

Result: You can use the `mssql_ha_prep_for_pacemaker` variable to configure SQL Server for Pacemaker.
