### PR TITLE
fix: Manage selinux context for custom storage directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,14 @@ Type: `bool`
 
 #### mssql_manage_selinux
 
-Whether to configure SELinux with the `enforcing` or `permissive` mode based on the value of the `mssql_run_selinux_confined` variable.
+Only applicable on RHEL 9 when running as a SELinux-confined application.
+
+Whether to manage SELinux.
+
+When set to `true`, configures the following SELinux contexts and settings:
+
+1. SELinux `enforcing` or `permissive` mode based on the value of the [mssql_run_selinux_confined](#mssql_run_selinux_confined) variable.
+2. When you define [mssql_datadir](#mssql_datadir) or [mssql_logdir](#mssql_logdir), configures SELinux context `mssql_db_t` for [mssql_datadir](#mssql_datadir) and `mssql_var_t` for [mssql_logdir](#mssql_logdir).
 
 Default: `false`
 
@@ -386,6 +393,10 @@ Type: `string`
 Optional: Use these variables to configure SQL Server to store data and logs in custom paths.
 
 ### Custom Paths Variables
+
+Use these variables to configure custom storage paths.
+
+On RHEL 9, you can set [mssql_manage_selinux](#mssql_manage_selinux) to `true` to set a correct SELinux context for custom directories.
 
 #### mssql_datadir
 

--- a/tasks/configure_storage_paths.yml
+++ b/tasks/configure_storage_paths.yml
@@ -20,6 +20,22 @@
       else
       __mssql_storage_mode_default }}"
 
+- name: Append facts for the selinux role
+  vars:
+    selinux_fcontext:
+      - target: "{{ __mssql_storage_path }}"
+        setype: "{{ 'mssql_db_t' if __mssql_storage_setting == 'defaultlogdir'
+          else 'mssql_var_t' }}"
+        ftype: d
+        state: present
+    selinux_restore_dir:
+      - "{{ __mssql_storage_path }}"
+  set_fact:
+    selinux_fcontexts: "{{
+      (selinux_fcontexts | default([])) + selinux_fcontext }}"
+    selinux_restore_dirs: "{{
+      (selinux_restore_dirs | default([])) + selinux_restore_dir }}"
+
 - name: Configure the setting {{ __mssql_storage_setting }}
   include_tasks: mssql_conf_setting.yml
   vars:

--- a/tasks/input_sql_files.yml
+++ b/tasks/input_sql_files.yml
@@ -27,8 +27,7 @@
   wait_for:
     path: /var/opt/mssql/log/errorlog
     search_regex: SQL Server is now ready for client connections
-    delay: 15
-    timeout: 40
+    delay: 1
 
 - name: Prepare MSSQL and facts for logging in
   include_tasks: verify_password.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -116,7 +116,7 @@
 
 - name: Gather package facts
   package_facts:
-    manager: auto
+  no_log: "{{ __mssql_gather_facts_no_log | d(false) }}"
 
 - name: Set fact with the currently installed SQL Server version if any
   set_fact:
@@ -280,6 +280,7 @@
 
 - name: Gather system services facts
   service_facts:
+  no_log: "{{ __mssql_gather_facts_no_log | d(false) }}"
 
 - name: Set the __mssql_is_setup variable
   set_fact:
@@ -340,6 +341,13 @@
     __mssql_storage_path: "{{ item.path }}"
     __mssql_storage_mode: "{{ item.mode }}"
     __mssql_storage_setting: "{{ item.setting }}"
+
+- name: Ensure correct SELinux context for {{ __mssql_storage_path }}
+  when:
+    - mssql_manage_selinux | bool
+    - (mssql_datadir is not none) or (mssql_logdir is not none)
+  include_role:
+    name: fedora.linux_system_roles.selinux
 
 - name: Ensure that the tuned-profiles-mssql package is installed
   package:
@@ -421,8 +429,7 @@
       wait_for:
         path: /var/opt/mssql/log/errorlog
         search_regex: SQL Server is now ready for client connections
-        delay: 15
-        timeout: 40
+        delay: 1
 
     - name: Check if the set password matches the existing password
       command: "{{ __mssql_sqlcmd_login_cmd }} -Q 'SELECT @@VERSION'"
@@ -430,6 +437,14 @@
       changed_when: false
       register: __mssql_password_query
       no_log: true
+      until: >-
+        "TCP Provider: Error code 0x102" not in __mssql_password_query.stdout
+        and
+        "TCP Provider: Error code 0x102" not in __mssql_password_query.stderr
+        and
+        "TCP Provider: Error code 0x2749" not in __mssql_password_query.stdout
+        and
+        "TCP Provider: Error code 0x2749" not in __mssql_password_query.stderr
 
     - name: Ensure that the mssql-server service is stopped
       service:
@@ -440,7 +455,7 @@
 
     - name: Gather package facts
       package_facts:
-        manager: auto
+      no_log: "{{ __mssql_gather_facts_no_log | d(false) }}"
 
     # Setting MSSQL_SA_PASSWORD inline for security because setting it with
     # environment: reveals the value when running playbooks with high verbosity
@@ -516,7 +531,7 @@
 
     - name: Gather package facts
       package_facts:
-        manager: auto
+      no_log: "{{ __mssql_gather_facts_no_log | d(false) }}"
 
     - name: Change the edition of MSSQL
       block:

--- a/tasks/sqlcmd_input_content.yml
+++ b/tasks/sqlcmd_input_content.yml
@@ -7,6 +7,12 @@
       register: __mssql_sqlcmd_input
       changed_when: '"successfully" in __mssql_sqlcmd_input.stdout'
       no_log: true
+      until: >-
+        "TCP Provider: Error code 0x102" not in __mssql_sqlcmd_input.stdout and
+        "TCP Provider: Error code 0x102" not in __mssql_sqlcmd_input.stderr and
+        "TCP Provider: Error code 0x2749" not in __mssql_sqlcmd_input.stdout and
+        "TCP Provider: Error code 0x2749" not in __mssql_sqlcmd_input.stderr
+
   always:
     # Role prints the output if the input succeeds, otherwise Ansible prints the
     # output from the failed input tasks

--- a/tasks/sqlcmd_input_file.yml
+++ b/tasks/sqlcmd_input_file.yml
@@ -31,6 +31,11 @@
       register: __mssql_sqlcmd_input
       changed_when: '"successfully" in __mssql_sqlcmd_input.stdout'
       no_log: true
+      until: >-
+        "TCP Provider: Error code 0x102" not in __mssql_sqlcmd_input.stdout and
+        "TCP Provider: Error code 0x102" not in __mssql_sqlcmd_input.stderr and
+        "TCP Provider: Error code 0x2749" not in __mssql_sqlcmd_input.stdout and
+        "TCP Provider: Error code 0x2749" not in __mssql_sqlcmd_input.stderr
   always:
     # Role prints the output if the input succeeds, otherwise Ansible prints the
     # output from the failed input tasks

--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -1,7 +1,6 @@
 ---
 - name: Gather package facts
   package_facts:
-    manager: auto
   no_log: true
 
 - name: Purge cluster configuration
@@ -63,11 +62,13 @@
     /var/log/pacemaker/pacemaker.log
     /etc/yum.repos.d/packages-microsoft-com-*
     /tmp/*.j2
+    /tmp/mssql_data
+    /tmp/mssql_log
     /etc/systemd/system/multi-user.target.wants/mssql-server.service
   register: __mssql_cleanup_remove
   changed_when: "'removed' in __mssql_cleanup_remove.stdout"
 
 # On SQL Server 2017, 2019 the service remains after removing RPMs
 - name: Stop the mssql-server service  # noqa command-instead-of-module
-  command: systemctl stop mssql-server  # noqa ignore-errors
-  ignore_errors: true  # noqa no-changed-when
+  shell: systemctl stop mssql-server || true
+  changed_when: false

--- a/tests/tasks/tests_idempotency.yml
+++ b/tests/tasks/tests_idempotency.yml
@@ -14,8 +14,8 @@
     mssql_install_fts: true
     mssql_tune_for_fua_storage: true
     mssql_install_powershell: true
-    mssql_datadir: /tmp/data
-    mssql_logdir: /tmp/log
+    mssql_datadir: /tmp/mssql_data
+    mssql_logdir: /tmp/mssql_log
     mssql_datadir_mode: '0700'
     mssql_logdir_mode: '0700'
 
@@ -34,8 +34,8 @@
     mssql_install_fts: true
     mssql_tune_for_fua_storage: true
     mssql_install_powershell: true
-    mssql_datadir: /tmp/data
-    mssql_logdir: /tmp/log
+    mssql_datadir: /tmp/mssql_data
+    mssql_logdir: /tmp/mssql_log
 
 - name: Verify settings
   include_tasks: verify_settings.yml
@@ -48,8 +48,8 @@
     __verify_mssql_fts_is_installed: true
     __verify_mssql_is_tuned_for_fua: true
     __verify_mssql_powershell_is_installed: true
-    __verify_mssql_datadir: /tmp/data
-    __verify_mssql_logdir: /tmp/log
+    __verify_mssql_datadir: /tmp/mssql_data
+    __verify_mssql_logdir: /tmp/mssql_log
     __verify_mssql_datadir_mode: '0700'
     __verify_mssql_logdir_mode: '0700'
 

--- a/tests/tasks/tests_input_sql_file.yml
+++ b/tests/tasks/tests_input_sql_file.yml
@@ -11,6 +11,9 @@
       - create_example_db.j2
     mssql_password: "p@55w0rD"
     mssql_edition: Evaluation
+    # Enable FTS in the beginning so that it works at the end
+    # It takes some time for mssql-server to configure it after RPM is installed
+    mssql_install_fts: true
     # noqa var-naming[no-role-prefix]
     __mssql_test_db_name: ExampleDB1
 
@@ -24,10 +27,14 @@
         'The Inventory table already exists, skipping' in
         __mssql_sqlcmd_input.stdout
 
-- name: Set up MSSQL and input sql files with post_input
+- name: Input sql files with post_input into custom storage directory
   include_role:
     name: linux-system-roles.mssql
   vars:
+    mssql_datadir: /tmp/mssql_data
+    mssql_logdir: /tmp/mssql_log
+    mssql_datadir_mode: '0700'
+    mssql_logdir_mode: '0700'
     mssql_post_input_sql_file:
       - sql_script.sql
       - sql_script.sql
@@ -42,6 +49,14 @@
       - >-
         'The MyUser user already exists, skipping'
         in __mssql_sqlcmd_input.stdout
+
+- name: Verify custom storage
+  include_tasks: verify_settings.yml
+  vars:
+    __verify_mssql_datadir: /tmp/mssql_data
+    __verify_mssql_logdir: /tmp/mssql_log
+    __verify_mssql_datadir_mode: '0700'
+    __verify_mssql_logdir_mode: '0700'
 
 - name: Set up MSSQL and input sql content with pre_input
   include_role:
@@ -112,11 +127,10 @@
           'You must define the mssql_password variable' in
           ansible_failed_result.msg
 
-- name: Enable FTS and verify that it works when inputting post script
+- name: Verify that FTS was enabled in the beginning of this test playbook
   include_role:
     name: linux-system-roles.mssql
   vars:
-    mssql_install_fts: true
     mssql_post_input_sql_file: verify_fts.sql
     mssql_password: "p@55w0rD"
 

--- a/tests/tasks/verify_settings.yml
+++ b/tests/tasks/verify_settings.yml
@@ -94,12 +94,21 @@
       wait_for:
         path: /var/opt/mssql/log/errorlog
         search_regex: SQL Server is now ready for client connections
-        delay: 18
-        timeout: 40
+        delay: 1
 
     - name: Check if the set password matches the existing password
       command: "{{ __mssql_sqlcmd_login_cmd }} -Q 'SELECT @@VERSION'"
       changed_when: false
+      register: __mssql_test_psw_query
+      until: >-
+        "TCP Provider: Error code 0x102" not in __mssql_test_psw_query.stdout
+        and
+        "TCP Provider: Error code 0x102" not in __mssql_test_psw_query.stderr
+        and
+        "TCP Provider: Error code 0x2749" not in __mssql_test_psw_query.stdout
+        and
+        "TCP Provider: Error code 0x2749" not in __mssql_test_psw_query.stderr
+
 
     - name: Set the mssql_password variable to default null
       set_fact:

--- a/tests/tests_2019_upgrade.yml
+++ b/tests/tests_2019_upgrade.yml
@@ -6,6 +6,7 @@
     mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
+    __mssql_gather_facts_no_log: true
   tasks:
     - name: Assert fail on EL 7 with version=2022 and EL 9 with version!=2022
       include_tasks: tasks/assert_fail_on_unsupported_ver.yml

--- a/tests/tests_2022_upgrade.yml
+++ b/tests/tests_2022_upgrade.yml
@@ -6,6 +6,7 @@
     mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
+    __mssql_gather_facts_no_log: true
   tasks:
     - name: Assert fail on EL 7 with version=2022 and EL 9 with version!=2022
       include_tasks: tasks/assert_fail_on_unsupported_ver.yml

--- a/tests/tests_accept_eula.yml
+++ b/tests/tests_accept_eula.yml
@@ -14,7 +14,7 @@
       (ansible_distribution_major_version is version('9', '>=')) }}"
     mssql_manage_selinux: "{{ __mssql_test_confined_supported }}"
     mssql_run_selinux_confined: "{{ __mssql_test_confined_supported }}"
-
+    __mssql_gather_facts_no_log: true
   tasks:
     - name: Run test in a block to clean up in always
       block:

--- a/tests/tests_configure_ha_cluster_external.yml
+++ b/tests/tests_configure_ha_cluster_external.yml
@@ -15,6 +15,7 @@
     __mssql_test_confined_supported: "{{
       (ansible_distribution in ['CentOS', 'RedHat']) and
       (ansible_distribution_major_version is version('9', '>=')) }}"
+    __mssql_gather_facts_no_log: true
     mssql_manage_selinux: "{{ __mssql_test_confined_supported }}"
     mssql_run_selinux_confined: "{{ __mssql_test_confined_supported }}"
     mssql_ha_configure: true

--- a/tests/tests_configure_ha_cluster_read_scale.yml
+++ b/tests/tests_configure_ha_cluster_read_scale.yml
@@ -11,11 +11,8 @@
     mssql_edition: Evaluation
     mssql_version: 2022
     mssql_manage_firewall: true
-    __mssql_test_confined_supported: "{{
-      (ansible_distribution in ['CentOS', 'RedHat']) and
-      (ansible_distribution_major_version is version('9', '>=')) }}"
-    mssql_manage_selinux: "{{ __mssql_test_confined_supported }}"
-    mssql_run_selinux_confined: "{{ __mssql_test_confined_supported }}"
+    __mssql_gather_facts_no_log: true
+    mssql_manage_selinux: "{{ mssql_run_selinux_confined }}"
     mssql_ha_configure: true
     mssql_ha_endpoint_port: 5022
     mssql_ha_cert_name: ExampleCert

--- a/tests/tests_idempotency_2017.yml
+++ b/tests/tests_idempotency_2017.yml
@@ -8,6 +8,7 @@
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2017
+    __mssql_gather_facts_no_log: true
   tasks:
     - name: Run test in a block to clean up in always
       block:

--- a/tests/tests_idempotency_2019.yml
+++ b/tests/tests_idempotency_2019.yml
@@ -8,6 +8,7 @@
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2019
+    __mssql_gather_facts_no_log: true
   tasks:
     - name: Run test in a block to clean up in always
       block:

--- a/tests/tests_idempotency_2022.yml
+++ b/tests/tests_idempotency_2022.yml
@@ -8,11 +8,8 @@
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2022
-    __mssql_test_confined_supported: "{{
-      (ansible_distribution in ['CentOS', 'RedHat']) and
-      (ansible_distribution_major_version is version('9', '>=')) }}"
-    mssql_manage_selinux: "{{ __mssql_test_confined_supported }}"
-    mssql_run_selinux_confined: "{{ __mssql_test_confined_supported }}"
+    mssql_manage_selinux: "{{ mssql_run_selinux_confined }}"
+    __mssql_gather_facts_no_log: true
   tasks:
     - name: Run test in a block to clean up in always
       block:

--- a/tests/tests_input_sql_file_2017.yml
+++ b/tests/tests_input_sql_file_2017.yml
@@ -8,6 +8,7 @@
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_debug: true
     mssql_version: 2017
+    __mssql_gather_facts_no_log: true
   tasks:
     - name: Run test in a block to clean up in always
       block:

--- a/tests/tests_input_sql_file_2019.yml
+++ b/tests/tests_input_sql_file_2019.yml
@@ -8,6 +8,7 @@
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_debug: true
     mssql_version: 2019
+    __mssql_gather_facts_no_log: true
   tasks:
     - name: Run test in a block to clean up in always
       block:

--- a/tests/tests_input_sql_file_2022.yml
+++ b/tests/tests_input_sql_file_2022.yml
@@ -8,11 +8,8 @@
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_debug: true
     mssql_version: 2022
-    __mssql_test_confined_supported: "{{
-      (ansible_distribution in ['CentOS', 'RedHat']) and
-      (ansible_distribution_major_version is version('9', '>=')) }}"
-    mssql_manage_selinux: "{{ __mssql_test_confined_supported }}"
-    mssql_run_selinux_confined: "{{ __mssql_test_confined_supported }}"
+    mssql_manage_selinux: "{{ mssql_run_selinux_confined }}"
+    __mssql_gather_facts_no_log: true
   tasks:
     - name: Run test in a block to clean up in always
       block:

--- a/tests/tests_password_2017.yml
+++ b/tests/tests_password_2017.yml
@@ -7,6 +7,7 @@
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2017
+    __mssql_gather_facts_no_log: true
   tasks:
     - name: Run test in a block to clean up in always
       block:

--- a/tests/tests_password_2019.yml
+++ b/tests/tests_password_2019.yml
@@ -7,6 +7,7 @@
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2019
+    __mssql_gather_facts_no_log: true
   tasks:
     - name: Run test in a block to clean up in always
       block:

--- a/tests/tests_password_2022.yml
+++ b/tests/tests_password_2022.yml
@@ -7,11 +7,8 @@
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2022
-    __mssql_test_confined_supported: "{{
-      (ansible_distribution in ['CentOS', 'RedHat']) and
-      (ansible_distribution_major_version is version('9', '>=')) }}"
-    mssql_manage_selinux: "{{ __mssql_test_confined_supported }}"
-    mssql_run_selinux_confined: "{{ __mssql_test_confined_supported }}"
+    mssql_manage_selinux: "{{ mssql_run_selinux_confined }}"
+    __mssql_gather_facts_no_log: true
   tasks:
     - name: Run test in a block to clean up in always
       block:

--- a/tests/tests_selinux_enforcing.yml
+++ b/tests/tests_selinux_enforcing.yml
@@ -10,6 +10,7 @@
     mssql_version: 2022
     mssql_password: "p@55w0rD"
     mssql_edition: Evaluation
+    __mssql_gather_facts_no_log: true
   tasks:
     - name: Assert expected failures on unsupported platforms
       include_tasks: tasks/assert_fail_on_unsupported_ver.yml

--- a/tests/tests_tcp_firewall_2017.yml
+++ b/tests/tests_tcp_firewall_2017.yml
@@ -8,6 +8,7 @@
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_manage_firewall: true
     mssql_version: 2017
+    __mssql_gather_facts_no_log: true
   tasks:
     - name: Run test in a block to clean up in always
       block:

--- a/tests/tests_tcp_firewall_2019.yml
+++ b/tests/tests_tcp_firewall_2019.yml
@@ -8,6 +8,7 @@
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_manage_firewall: true
     mssql_version: 2019
+    __mssql_gather_facts_no_log: true
   tasks:
     - name: Run test in a block to clean up in always
       block:

--- a/tests/tests_tcp_firewall_2022.yml
+++ b/tests/tests_tcp_firewall_2022.yml
@@ -8,11 +8,8 @@
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_manage_firewall: true
     mssql_version: 2022
-    __mssql_test_confined_supported: "{{
-      (ansible_distribution in ['CentOS', 'RedHat']) and
-      (ansible_distribution_major_version is version('9', '>=')) }}"
-    mssql_manage_selinux: "{{ __mssql_test_confined_supported }}"
-    mssql_run_selinux_confined: "{{ __mssql_test_confined_supported }}"
+    mssql_manage_selinux: "{{ mssql_run_selinux_confined }}"
+    __mssql_gather_facts_no_log: true
   tasks:
     - name: Run test in a block to clean up in always
       block:

--- a/tests/tests_tls_2017.yml
+++ b/tests/tests_tls_2017.yml
@@ -10,6 +10,7 @@
     mssql_edition: Evaluation
     mssql_tcp_port: 1433
     mssql_version: 2017
+    __mssql_gather_facts_no_log: true
   tasks:
     - name: Run test in a block to clean up in always
       block:

--- a/tests/tests_tls_2019.yml
+++ b/tests/tests_tls_2019.yml
@@ -10,6 +10,7 @@
     mssql_edition: Evaluation
     mssql_tcp_port: 1433
     mssql_version: 2019
+    __mssql_gather_facts_no_log: true
   tasks:
     - name: Run test in a block to clean up in always
       block:

--- a/tests/tests_tls_2022.yml
+++ b/tests/tests_tls_2022.yml
@@ -10,11 +10,8 @@
     mssql_edition: Evaluation
     mssql_tcp_port: 1433
     mssql_version: 2022
-    __mssql_test_confined_supported: "{{
-      (ansible_distribution in ['CentOS', 'RedHat']) and
-      (ansible_distribution_major_version is version('9', '>=')) }}"
-    mssql_manage_selinux: "{{ __mssql_test_confined_supported }}"
-    mssql_run_selinux_confined: "{{ __mssql_test_confined_supported }}"
+    mssql_manage_selinux: "{{ mssql_run_selinux_confined }}"
+    __mssql_gather_facts_no_log: true
   tasks:
     - name: Run test in a block to clean up in always
       block:


### PR DESCRIPTION
Enhancement: On RHEL 9, manage SELinux context for custom storage paths

Reason: SQL Server runs on RHEL 9 as a SELinux-confined application and requires custom storage paths to have the correct SELinux context.

Result: When user sets `mssql_manage_selinux: true`, the role configures directories provided with `mssql_logdir` and `mssql_datadir` with a proper SELinux context.
