### PR TITLE
chore: Deprecate mssql_ha_cluster_run_role for mssql_manage_ha_cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,7 +675,7 @@ Configuring for high availability is not supported on RHEL 7 because the `fedora
 
 You must set the `mssql_ha_replica_type` variable for each host that you want to configure.
 
-If you set [mssql_ha_cluster_run_role](#mssql_ha_cluster_run_role) to `true`, you can provide variables required by the `fedora.linux_system_roles.ha_cluster` role.
+If you set [mssql_manage_ha_cluster](#mssql_manage_ha_cluster) to `true`, you can provide variables required by the `fedora.linux_system_roles.ha_cluster` role.
 If you do not provide names or addresses, the `fedora.linux_system_roles.ha_cluster` uses play's targets, and the high availability setup requires pacemaker to be configured with short names.
 Therefore, if you define hosts in inventory not by short names, or the default hosts' IP address differs from the IP address that pacemaker must use, you must set the corresponding `fedora.linux_system_roles.ha_cluster` role variables.
 
@@ -706,8 +706,8 @@ When set to `true`, the role performs the following tasks:
     2. Configure the user provided with the [mssql_ha_login](#mssql_ha_login) variable for
       Pacemaker.
     3. Configure virtual IP.
-4. When [`mssql_ha_cluster_run_role`](#mssql_ha_cluster_run_role)`=true`: Include the `fedora.linux_system_roles.ha_cluster` role to configure Pacemaker.
-  You must set [mssql_ha_cluster_run_role](#mssql_ha_cluster_run_role) to `true` and provide all variables required by the `fedora.linux_system_roles.ha_cluster` role for a proper Pacemaker cluster configuration based on example playbooks in [Always On Availability Group Example Playbooks](#always-on-availability-group-example-playbooks).
+4. When [`mssql_manage_ha_cluster`](#mssql_manage_ha_cluster)`=true`: Include the `fedora.linux_system_roles.ha_cluster` role to configure Pacemaker.
+  You must set [mssql_manage_ha_cluster](#mssql_manage_ha_cluster) to `true` and provide all variables required by the `fedora.linux_system_roles.ha_cluster` role for a proper Pacemaker cluster configuration based on example playbooks in [Always On Availability Group Example Playbooks](#always-on-availability-group-example-playbooks).
 
 Default: `false`
 
@@ -886,7 +886,7 @@ Default: `null`
 
 Type: `string`
 
-#### mssql_ha_cluster_run_role
+#### mssql_manage_ha_cluster
 
 Whether to run the `fedora.linux_system_roles.ha_cluster` role from this role.
 
@@ -898,9 +898,9 @@ Note that the `fedora.linux_system_roles.ha_cluster` role has the following limi
 
 To work around this limitation, the `microsoft.sql.server` role does not set any variables for the `fedora.linux_system_roles.ha_cluster` role to ensure that any existing Pacemaker configuration is not re-written.
 
-If you want the `microsoft.sql.server` to run the `fedora.linux_system_roles.ha_cluster` role, set `mssql_ha_cluster_run_role: true` and provide variables for the `fedora.linux_system_roles.ha_cluster` role with the `microsoft.sql.server` role invocation based on example playbooks in [Always On Availability Group Example Playbooks](#always-on-availability-group-example-playbooks).
+If you want the `microsoft.sql.server` to run the `fedora.linux_system_roles.ha_cluster` role, set `mssql_manage_ha_cluster: true` and provide variables for the `fedora.linux_system_roles.ha_cluster` role with the `microsoft.sql.server` role invocation based on example playbooks in [Always On Availability Group Example Playbooks](#always-on-availability-group-example-playbooks).
 
-If you do not want the `microsoft.sql.server` to run the `fedora.linux_system_roles.ha_cluster` role and instead want to run the `fedora.linux_system_roles.ha_cluster` role independently of the `microsoft.sql.server` role, set `mssql_ha_cluster_run_role: false`.
+If you do not want the `microsoft.sql.server` to run the `fedora.linux_system_roles.ha_cluster` role and instead want to run the `fedora.linux_system_roles.ha_cluster` role independently of the `microsoft.sql.server` role, set `mssql_manage_ha_cluster: false`.
 
 Default: `false`
 
@@ -998,7 +998,7 @@ Playbook:
 
 #### Configuring SQL Server with HA and Pacemaker on Bare Metal
 
-If you want to configure Pacemaker from this role, you can set [mssql_ha_cluster_run_role](#mssql_ha_cluster_run_role) to `true` and provide variables required by the `fedora.linux_system_roles.ha_cluster` role to configure Pacemaker for your environment properly.
+If you want to configure Pacemaker from this role, you can set [mssql_manage_ha_cluster](#mssql_manage_ha_cluster) to `true` and provide variables required by the `fedora.linux_system_roles.ha_cluster` role to configure Pacemaker for your environment properly.
 
 This example configures required Pacemaker properties and resources and enables SBD watchdog.
 
@@ -1030,7 +1030,7 @@ For more information, see the `fedora.linux_system_roles.ha_cluster` role docume
     mssql_ha_login: ExampleLogin
     mssql_ha_login_password: "p@55w0rD3"
     mssql_ha_virtual_ip: 192.XXX.XXX.XXX
-    mssql_ha_cluster_run_role: true
+    mssql_manage_ha_cluster: true
     ha_cluster_cluster_name: "{{ mssql_ha_ag_name }}"
     ha_cluster_hacluster_password: "p@55w0rD4"
     ha_cluster_sbd_enabled: true
@@ -1095,7 +1095,7 @@ For more information, see the `fedora.linux_system_roles.ha_cluster` role docume
 
 #### Configuring SQL Server with HA and Pacemaker on VMWare
 
-If you want to configure Pacemaker from this role, you can set [mssql_ha_cluster_run_role](#mssql_ha_cluster_run_role) to `true` and provide variables required by the `fedora.linux_system_roles.ha_cluster` role to configure Pacemaker for your environment properly.
+If you want to configure Pacemaker from this role, you can set [mssql_manage_ha_cluster](#mssql_manage_ha_cluster) to `true` and provide variables required by the `fedora.linux_system_roles.ha_cluster` role to configure Pacemaker for your environment properly.
 See the `fedora.linux_system_roles.ha_cluster` role documentation for more information.
 
 Note that production environments require Pacemaker configured with fencing agents, this example playbook configures the `stonith:fence_vmware_soap` agent.
@@ -1125,7 +1125,7 @@ Note that production environments require Pacemaker configured with fencing agen
     mssql_ha_login: ExampleLogin
     mssql_ha_login_password: "p@55w0rD3"
     mssql_ha_virtual_ip: 192.XXX.XXX.XXX
-    mssql_ha_cluster_run_role: true
+    mssql_manage_ha_cluster: true
     ha_cluster_cluster_name: "{{ mssql_ha_ag_name }}"
     ha_cluster_hacluster_password: "p@55w0rD4"
     ha_cluster_cluster_properties:
@@ -1199,7 +1199,7 @@ Note that production environments require Pacemaker configured with fencing agen
 
 #### Configuring SQL Server with HA and Pacemaker on Azure
 
-If you want to configure Pacemaker from this role, you can set [mssql_ha_cluster_run_role](#mssql_ha_cluster_run_role) to `true` and provide variables required by the `fedora.linux_system_roles.ha_cluster` role to configure Pacemaker for your environment properly.
+If you want to configure Pacemaker from this role, you can set [mssql_manage_ha_cluster](#mssql_manage_ha_cluster) to `true` and provide variables required by the `fedora.linux_system_roles.ha_cluster` role to configure Pacemaker for your environment properly.
 See the `fedora.linux_system_roles.ha_cluster` role documentation for more information.
 
 #### HA and Pacemaker on Azure Prerequisites
@@ -1241,7 +1241,7 @@ This example playbooks sets the `firewall` variables for the `fedora.linux_syste
     # Set mssql_ha_virtual_ip to the frontend IP address configured in the Azure
     # load balancer
     mssql_ha_virtual_ip: 192.XXX.XXX.XXX
-    mssql_ha_cluster_run_role: true
+    mssql_manage_ha_cluster: true
     ha_cluster_cluster_name: "{{ mssql_ha_ag_name }}"
     ha_cluster_hacluster_password: "p@55w0rD4"
     ha_cluster_extra_packages:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,7 +55,7 @@ mssql_ha_prep_for_pacemaker: "{{ mssql_ha_ag_cluster_type | lower != 'none' }}"
 mssql_ha_virtual_ip: null
 mssql_ha_login: null
 mssql_ha_login_password: null
-mssql_ha_cluster_run_role: false
+mssql_manage_ha_cluster: false
 
 mssql_ad_configure: false
 mssql_ad_join: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,6 +52,20 @@
       set_fact:
         mssql_ad_sql_user: "{{ mssql_ad_sql_user_name }}"
 
+- name: Link the deprecated mssql_ha_cluster_run_role fact
+  when: mssql_ha_cluster_run_role is defined
+  block:
+    - name: Print that the mssql_ha_cluster_run_role variable is deprecated
+      debug:
+        msg: >-
+          The mssql_ha_cluster_run_role variable is deprecated and will be
+          removed in a future version. Edit your playbook to use
+          mssql_manage_ha_cluster variable instead.
+
+    - name: Link the deprecated mssql_ha_cluster_run_role fact
+      set_fact:
+        mssql_manage_ha_cluster: "{{ mssql_ha_cluster_run_role }}"
+
 - name: Verify that the user accepts EULA variables
   assert:
     that:
@@ -98,11 +112,11 @@
   when:
     - mssql_ha_ag_cluster_type | lower == 'none'
     - (mssql_ha_prep_for_pacemaker | bool)
-      or (mssql_ha_cluster_run_role | bool)
+      or (mssql_manage_ha_cluster | bool)
   fail:
     msg: >-
       You set mssql_ha_ag_cluster_type to none, in this case you must not set
-      mssql_ha_prep_for_pacemaker and mssql_ha_cluster_run_role to true because
+      mssql_ha_prep_for_pacemaker and mssql_manage_ha_cluster to true because
       read-scale clusters do not require Pacemaker
 
 - name: Verify that selinux variables are used on supported platforms
@@ -1293,7 +1307,7 @@
         - name: Run ha_cluster to configure pacemaker
           include_role:
             name: fedora.linux_system_roles.ha_cluster
-          when: mssql_ha_cluster_run_role | bool
+          when: mssql_manage_ha_cluster | bool
 
     # Configure on a current primary identified above
     - name: Configure listener for the availability group {{ mssql_ha_ag_name }}

--- a/tests/tests_configure_ha_cluster_external.yml
+++ b/tests/tests_configure_ha_cluster_external.yml
@@ -34,7 +34,7 @@
     mssql_ha_login_password: "p@55w0rD3"
     mssql_ha_virtual_ip: 192.168.122.148
     # ha_cluster doesn't support running against a single host
-    mssql_ha_cluster_run_role: "{{ ansible_play_hosts_all | length > 1 }}"
+    mssql_manage_ha_cluster: "{{ ansible_play_hosts_all | length > 1 }}"
     ha_cluster_cluster_name: "{{ mssql_ha_ag_name }}"
     ha_cluster_hacluster_password: "p@55w0rD4"
     ha_cluster_sbd_enabled: true


### PR DESCRIPTION
Enhancement: Deprecate mssql_ha_cluster_run_role for mssql_manage_ha_cluster.

Reason: System roles consistently use variables in the form `mssql_manage_<rolename>` for managing components with other system roles. This role already uses `mssql_manage_firewall` and `mssql_manage_selinux`. Renaming `mssql_ha_cluster_run_role` to `mssql_manage_ha_cluster` brings consistency to variables names.

Result: When you set the deprecated `mssql_ha_cluster_run_role` variable, the role prints a message that this variable is deprecated and continues. 

