### PR TITLE
ci: support ansible-lint and ansible-test 2.16

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,4 @@
+---
 # Default state for all rules
 default: true
 

--- a/tests/roles/caller/tasks/main.yml
+++ b/tests/roles/caller/tasks/main.yml
@@ -1,8 +1,10 @@
 ---
 # tasks file for caller
 
-- include_role:
+- name: Include role
+  include_role:
     name: "{{ roletoinclude }}"
 
-- assert:
+- name: Test variable override
+  assert:
     that: not __caller_override

--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -1,71 +1,55 @@
 ---
-- name: Test role variable override
+- name: Test role include variable override
   hosts: all
+  gather_facts: true
   tasks:
-    - name: Run test in a block to clean up in always
-      block:
-        - name: >-
-            Create var file in caller that can override the one in called role
-          delegate_to: localhost
-          copy:
-            # usually the fake file will cause the called role to crash of
-            # overriding happens, but if not, set a variable that will
-            # allow to detect the bug
-            content: "__caller_override: true"
-            # XXX ugly, self-modifying code - changes the "caller" role on
-            # the controller
-            dest: "{{ playbook_dir }}/roles/caller/vars/{{ item }}.yml"
-            mode: preserve
-          loop: "{{ varfiles | unique }}"
-          # In case the playbook is executed against multiple hosts, use
-          # only the first one. Otherwise the hosts would stomp on each
-          # other since they are changing files on the controller.
-          when: inventory_hostname == ansible_play_hosts_all[0]
-          vars:
-            # change to hostvars['localhost']['ansible_facts'] to use the
-            # information for localhost
-            facts: "{{ ansible_facts }}"
-            versions:
-              - "{{ facts['distribution_version'] }}"
-              - "{{ facts['distribution_major_version'] }}"
-            separators: ["-", "_"]
-            # create all variants like CentOS, CentOS_8.1, CentOS-8.1,
-            # CentOS-8, CentOS-8.1
-            # more formally:
-            # {{ ansible_distribution }}-{{ ansible_distribution_version }}
-            # {{ ansible_distribution }}-\
-            # {{ ansible_distribution_major_version }}
-            # {{ ansible_distribution }}
-            # {{ ansible_os_family }}
-            # and the same for _ as separator.
-            varfiles: "{{ [facts['distribution']] | product(separators) |
-              map('join') | product(versions) | map('join') | list +
-              [facts['distribution'], facts['os_family']] }}"
+    - name: Create var file in caller that can override the one in called role
+      delegate_to: localhost
+      copy:
+        # usually the fake file will cause the called role to crash of
+        # overriding happens, but if not, set a variable that will
+        # allow to detect the bug
+        content: "__caller_override: true"
+        # XXX ugly, self-modifying code - changes the "caller" role on
+        # the controller
+        dest: "{{ playbook_dir }}/roles/caller/vars/{{ item }}.yml"
+        mode: preserve
+      loop: "{{ varfiles | unique }}"
+      # In case the playbook is executed against multiple hosts, use
+      # only the first one. Otherwise the hosts would stomp on each
+      # other since they are changing files on the controller.
+      when: inventory_hostname == ansible_play_hosts_all[0]
+      vars:
+        # change to hostvars['localhost']['ansible_facts'] to use the
+        # information for localhost
+        facts: "{{ ansible_facts }}"
+        versions:
+          - "{{ facts['distribution_version'] }}"
+          - "{{ facts['distribution_major_version'] }}"
+        separators: ["-", "_"]
+        # create all variants like CentOS, CentOS_8.1, CentOS-8.1,
+        # CentOS-8, CentOS-8.1
+        # more formally:
+        # {{ ansible_distribution }}-{{ ansible_distribution_version }}
+        # {{ ansible_distribution }}-{{ ansible_distribution_major_version }}
+        # {{ ansible_distribution }}
+        # {{ ansible_os_family }}
+        # and the same for _ as separator.
+        varfiles: "{{ [facts['distribution']] | product(separators) |
+          map('join') | product(versions) | map('join') | list +
+          [facts['distribution'], facts['os_family']] }}"
+      register: __varfiles_created
 
-        - name: Import role
-          import_role:
-            name: caller
-          vars:
-            roletoinclude: linux-system-roles.mssql
-            # noqa var-naming[no-role-prefix]
-            mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
-            # noqa var-naming[no-role-prefix]
-            mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
-            # noqa var-naming[no-role-prefix]
-            mssql_accept_microsoft_sql_server_standard_eula: true
-            # noqa var-naming[no-role-prefix]
-            mssql_version: "{{
-              '2022' if ansible_distribution_major_version is version('9', '>=')
-              else '2017' }}"
-            # noqa var-naming[no-role-prefix]
-            mssql_password: P@55w0rD
-            # noqa var-naming[no-role-prefix]
-            mssql_edition: Evaluation
-            __mssql_test_confined_supported: "{{
-              (ansible_distribution in ['CentOS', 'RedHat']) and
-              (ansible_distribution_major_version is version('9', '>=')) }}"
-            mssql_manage_selinux: "{{ __mssql_test_confined_supported }}"
-            mssql_run_selinux_confined: "{{ __mssql_test_confined_supported }}"
-      always:
-        - name: Clean up after the role invocation
-          include_tasks: tasks/cleanup.yml
+    - name: Import role
+      import_role:
+        name: caller
+      vars:
+        roletoinclude: linux-system-roles.mssql
+
+    - name: Cleanup
+      file:
+        path: "{{ item.dest }}"
+        state: absent
+      loop: "{{ __varfiles_created.results }}"
+      delegate_to: localhost
+      when: inventory_hostname == ansible_play_hosts_all[0]

--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -3,53 +3,73 @@
   hosts: all
   gather_facts: true
   tasks:
-    - name: Create var file in caller that can override the one in called role
-      delegate_to: localhost
-      copy:
-        # usually the fake file will cause the called role to crash of
-        # overriding happens, but if not, set a variable that will
-        # allow to detect the bug
-        content: "__caller_override: true"
-        # XXX ugly, self-modifying code - changes the "caller" role on
-        # the controller
-        dest: "{{ playbook_dir }}/roles/caller/vars/{{ item }}.yml"
-        mode: preserve
-      loop: "{{ varfiles | unique }}"
-      # In case the playbook is executed against multiple hosts, use
-      # only the first one. Otherwise the hosts would stomp on each
-      # other since they are changing files on the controller.
-      when: inventory_hostname == ansible_play_hosts_all[0]
-      vars:
-        # change to hostvars['localhost']['ansible_facts'] to use the
-        # information for localhost
-        facts: "{{ ansible_facts }}"
-        versions:
-          - "{{ facts['distribution_version'] }}"
-          - "{{ facts['distribution_major_version'] }}"
-        separators: ["-", "_"]
-        # create all variants like CentOS, CentOS_8.1, CentOS-8.1,
-        # CentOS-8, CentOS-8.1
-        # more formally:
-        # {{ ansible_distribution }}-{{ ansible_distribution_version }}
-        # {{ ansible_distribution }}-{{ ansible_distribution_major_version }}
-        # {{ ansible_distribution }}
-        # {{ ansible_os_family }}
-        # and the same for _ as separator.
-        varfiles: "{{ [facts['distribution']] | product(separators) |
-          map('join') | product(versions) | map('join') | list +
-          [facts['distribution'], facts['os_family']] }}"
-      register: __varfiles_created
+    - name: Run test in a block to clean up in always
+      block:
+        - name: >-
+            Create var file in caller that can override the one in called role
+          delegate_to: localhost
+          copy:
+            # usually the fake file will cause the called role to crash of
+            # overriding happens, but if not, set a variable that will
+            # allow to detect the bug
+            content: "__caller_override: true"
+            # XXX ugly, self-modifying code - changes the "caller" role on
+            # the controller
+            dest: "{{ playbook_dir }}/roles/caller/vars/{{ item }}.yml"
+            mode: preserve
+          loop: "{{ varfiles | unique }}"
+          # In case the playbook is executed against multiple hosts, use
+          # only the first one. Otherwise the hosts would stomp on each
+          # other since they are changing files on the controller.
+          when: inventory_hostname == ansible_play_hosts_all[0]
+          vars:
+            # change to hostvars['localhost']['ansible_facts'] to use the
+            # information for localhost
+            facts: "{{ ansible_facts }}"
+            versions:
+              - "{{ facts['distribution_version'] }}"
+              - "{{ facts['distribution_major_version'] }}"
+            separators: ["-", "_"]
+            # create all variants like CentOS, CentOS_8.1, CentOS-8.1,
+            # CentOS-8, CentOS-8.1
+            # more formally:
+            # {{ ansible_distribution }}-{{ ansible_distribution_version }}
+            # {{ ansible_distribution }}-\
+            # {{ ansible_distribution_major_version }}
+            # {{ ansible_distribution }}
+            # {{ ansible_os_family }}
+            # and the same for _ as separator.
+            varfiles: "{{ [facts['distribution']] | product(separators) |
+              map('join') | product(versions) | map('join') | list +
+              [facts['distribution'], facts['os_family']] }}"
+          register: __varfiles_created
 
-    - name: Import role
-      import_role:
-        name: caller
-      vars:
-        roletoinclude: linux-system-roles.mssql
+        - name: Import role
+          import_role:
+            name: caller
+          vars:
+            roletoinclude: linux-system-roles.mssql
+            mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+            mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
+            mssql_accept_microsoft_sql_server_standard_eula: true
+            mssql_version: "{{
+              '2022' if ansible_distribution_major_version is version('9', '>=')
+              else '2017' }}"
+            mssql_password: P@55w0rD
+            mssql_edition: Evaluation
+            __mssql_test_confined_supported: "{{
+              (ansible_distribution in ['CentOS', 'RedHat']) and
+              (ansible_distribution_major_version is version('9', '>=')) }}"
+            mssql_manage_selinux: "{{ __mssql_test_confined_supported }}"
+            mssql_run_selinux_confined: "{{ __mssql_test_confined_supported }}"
+      always:
+        - name: Cleanup
+          file:
+            path: "{{ item.dest }}"
+            state: absent
+          loop: "{{ __varfiles_created.results }}"
+          delegate_to: localhost
+          when: inventory_hostname == ansible_play_hosts_all[0]
 
-    - name: Cleanup
-      file:
-        path: "{{ item.dest }}"
-        state: absent
-      loop: "{{ __varfiles_created.results }}"
-      delegate_to: localhost
-      when: inventory_hostname == ansible_play_hosts_all[0]
+        - name: Clean up after the role invocation
+          include_tasks: tasks/cleanup.yml


### PR DESCRIPTION
Fix yamllint issue with markdownlint config

Add cleanup for tests_include_vars_from_parent.yml

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
