### PR TITLE
fix:  Ensure selinux type for used ports, set default data and log dirmode

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,12 +413,9 @@ Type: `string`
 
 The permissions to be set for the `mssql_datadir` path in the format of the Ansible `file` module `mode` variable.
 
-Quote the mode like `'0700'` so Ansible parses it as a string to avoid conflicts with octal numbers.
+Quote the mode like `'755'` so Ansible parses it as a string to avoid conflicts with octal numbers.
 
-If mode is not specified and the destination directory *does not* exist, the role uses the default umask on the system when setting the mode.
-If mode is not specified and the destination directory *does* exist, the role uses the mode of the existing directory.
-
-Default: `null`
+Default: `'755'`
 
 Type: `string`
 
@@ -437,12 +434,9 @@ Type: `string`
 
 The permissions to be set for the `mssql_logdir` path in the format of the Ansible `file` module `mode` variable.
 
-Quote the mode like `'0700'` so Ansible parses it as a string to avoid conflicts with octal numbers.
+Quote the mode like `'755'` so Ansible parses it as a string to avoid conflicts with octal numbers.
 
-If mode is not specified and the destination directory *does not* exist, the role uses the default umask on the system when setting the mode.
-If mode is not specified and the destination directory *does* exist, the role uses the mode of the existing directory.
-
-Default: `null`
+Default: `'755'`
 
 Type: `string`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,9 +15,9 @@ mssql_install_fts: null
 mssql_install_powershell: null
 mssql_tune_for_fua_storage: null
 mssql_datadir: null
-mssql_datadir_mode: null
+mssql_datadir_mode: '755'
 mssql_logdir: null
-mssql_logdir_mode: null
+mssql_logdir_mode: '755'
 
 mssql_pre_input_sql_file: []
 mssql_post_input_sql_file: []

--- a/tasks/configure_storage_paths.yml
+++ b/tasks/configure_storage_paths.yml
@@ -1,24 +1,13 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Get stat of the directory {{ __mssql_storage_path }}
-  stat:
-    path: "{{ __mssql_storage_path }}"
-  register: __mssql_storage_path_stat
-
 - name: >-
-    Ensure the directory and keep present permissions {{ __mssql_storage_path }}
-  file:  # noqa risky-file-permissions
+    Ensure the directory and permissions {{ __mssql_storage_path }}
+  file:
     path: "{{ __mssql_storage_path }}"
     state: directory
     owner: mssql
     group: mssql
-    mode: "{{
-      __mssql_storage_mode if __mssql_storage_mode != ''
-      else
-      __mssql_storage_path_stat.stat.mode
-      if __mssql_storage_path_stat.stat.exists
-      else
-      __mssql_storage_mode_default }}"
+    mode: "{{ __mssql_storage_mode }}"
 
 - name: Append facts for the selinux role
   vars:
@@ -35,6 +24,7 @@
       (selinux_fcontexts | default([])) + selinux_fcontext }}"
     selinux_restore_dirs: "{{
       (selinux_restore_dirs | default([])) + selinux_restore_dir }}"
+  when: mssql_manage_selinux | bool
 
 - name: Configure the setting {{ __mssql_storage_setting }}
   include_tasks: mssql_conf_setting.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -356,10 +356,25 @@
     __mssql_storage_mode: "{{ item.mode }}"
     __mssql_storage_setting: "{{ item.setting }}"
 
-- name: Ensure correct SELinux context for {{ __mssql_storage_path }}
+- name: Set selinux role facts for ports
+  set_fact:
+    selinux_ports:
+      - ports: >-
+          {{ mssql_tcp_port }}
+          {{ mssql_ha_configure | ternary(', ' ~ mssql_ha_endpoint_port, '') }}
+        proto: tcp
+        setype: mssql_port_t
+        state: present
+        local: true
+  when: mssql_manage_selinux | bool
+
+- name: Ensure correct SELinux context for storage paths and ports
   when:
     - mssql_manage_selinux | bool
-    - (mssql_datadir is not none) or (mssql_logdir is not none)
+    - >-
+      (selinux_fcontexts is defined) or
+      (selinux_restore_dirs is defined) or
+      (selinux_ports is defined)
   include_role:
     name: fedora.linux_system_roles.selinux
 

--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -17,12 +17,17 @@
 
 - name: Purge firewall configuration
   vars:
-    # noqa var-naming[no-role-prefix]
     firewall:
       - previous: replaced
   include_role:
     name: fedora.linux_system_roles.firewall
   when: ansible_facts.packages.firewalld is defined
+
+- name: Purge selinux configuration
+  vars:
+    selinux_all_purge: true
+  include_role:
+    name: fedora.linux_system_roles.selinux
 
 - name: Leave realm
   command: realm leave

--- a/tests/tasks/tests_idempotency.yml
+++ b/tests/tasks/tests_idempotency.yml
@@ -16,8 +16,6 @@
     mssql_install_powershell: true
     mssql_datadir: /tmp/mssql_data
     mssql_logdir: /tmp/mssql_log
-    mssql_datadir_mode: '0700'
-    mssql_logdir_mode: '0700'
 
 - name: Configure the mssql-server service start limit interval and burst
   include_tasks: mssql-sever-increase-start-limit.yml
@@ -50,8 +48,6 @@
     __verify_mssql_powershell_is_installed: true
     __verify_mssql_datadir: /tmp/mssql_data
     __verify_mssql_logdir: /tmp/mssql_log
-    __verify_mssql_datadir_mode: '0700'
-    __verify_mssql_logdir_mode: '0700'
 
 - name: Run to edit settings
   include_role:
@@ -67,8 +63,8 @@
     mssql_install_powershell: false
     mssql_datadir: /var/opt/mssql/data
     mssql_logdir: /var/opt/mssql/log
-    mssql_datadir_mode: '0755'
-    mssql_logdir_mode: '0755'
+    mssql_datadir_mode: '755'
+    mssql_logdir_mode: '755'
 
 - name: Run with the edited settings again - should report not changed
   include_role:

--- a/tests/tests_configure_ha_cluster_external.yml
+++ b/tests/tests_configure_ha_cluster_external.yml
@@ -428,7 +428,7 @@
             # noqa var-naming[no-role-prefix]
             __mssql_sql_files_to_input:
               - configure_listener.j2
-            mssql_tcp_port: 1434
+            mssql_tcp_port: 1435
             mssql_ha_virtual_ip: 192.168.122.149
           include_role:
             name: linux-system-roles.mssql
@@ -444,7 +444,7 @@
                 "Modifying the listener port setting"
                 in __mssql_sqlcmd_input.stdout
               - >-
-                "Set listener port to 1434 successfully"
+                "Set listener port to 1435 successfully"
                 in __mssql_sqlcmd_input.stdout
               - >-
                 "Modifying the listener ip address setting"


### PR DESCRIPTION
Enhancement:

1. Ensure SELinux type for used ports
2. Set default mode for data and log storage directories 

Reason:

1. Custom TCP ports must have `mssql_port_t` SELinux type
3. `mssql_datadir_mode` and `mssql_logdir_mode` should have a default value for security

Result:

1. When mssql_manage_selinux is set to `true`, the role configures used ports with the `mssql_port_t` SELinux type
2. `mssql_datadir_mode` and `mssql_logdir_mode` variables have a default value of `'755'`