### PR TITLE
fix: Make the role wait for ha_cluster to finish configuration

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1324,6 +1324,11 @@
             name: fedora.linux_system_roles.ha_cluster
           when: mssql_manage_ha_cluster | bool
 
+        - name: Wait for the cluster to finish configuration
+          command: crm_resource --wait
+          changed_when: false
+          when: mssql_manage_ha_cluster | bool
+
     # Configure on a current primary identified above
     - name: Configure listener for the availability group {{ mssql_ha_ag_name }}
       vars:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -332,6 +332,11 @@
       register: __mssql_conf_setup
       no_log: true
       changed_when: true
+      until: >-
+        "Initial setup of Microsoft SQL Server failed."
+        not in __mssql_conf_setup.stdout and
+        "Initial setup of Microsoft SQL Server failed."
+        not in __mssql_conf_setup.stderr
   rescue:
     - name: Print output of failed task
       when: item | length > 0

--- a/tasks/sqlcmd_input_file.yml
+++ b/tasks/sqlcmd_input_file.yml
@@ -32,6 +32,8 @@
       changed_when: '"successfully" in __mssql_sqlcmd_input.stdout'
       no_log: true
       until: >-
+        "TCP Provider: Error code 0x68" not in __mssql_sqlcmd_input.stdout and
+        "TCP Provider: Error code 0x68" not in __mssql_sqlcmd_input.stderr and
         "TCP Provider: Error code 0x102" not in __mssql_sqlcmd_input.stdout and
         "TCP Provider: Error code 0x102" not in __mssql_sqlcmd_input.stderr and
         "TCP Provider: Error code 0x2749" not in __mssql_sqlcmd_input.stdout and

--- a/tests/tests_configure_ha_cluster_external.yml
+++ b/tests/tests_configure_ha_cluster_external.yml
@@ -184,9 +184,10 @@
         - name: Assert that pcs runs properly when testing against >3 nodes
           when: ansible_play_hosts_all | length >= 3
           block:
-            - name: Wait for pcs to finish configuration
-              wait_for:
-                timeout: 200
+            - name: Wait for the cluster to finish configuration
+              command: crm_resource --wait
+              changed_when: false
+              when: mssql_manage_ha_cluster | bool
 
             - name: Get global pcs status
               command: pcs status
@@ -218,12 +219,13 @@
               run_once: true
               changed_when: true
 
-            - name: Wait for syncrhonous node to promote for virtualip resource
-              wait_for:
-                timeout: 240
+            - name: Wait for the cluster to finish configuration
+              command: crm_resource --wait
+              changed_when: false
+              when: mssql_manage_ha_cluster | bool
 
             - name: Get global pcs status
-              command: pcs status resources virtualip
+              command: pcs status resources
               register: __pcs_status
               changed_when: false
 

--- a/tests/tests_selinux_enforcing_2022.yml
+++ b/tests/tests_selinux_enforcing_2022.yml
@@ -98,6 +98,6 @@
                 that: >-
                   'You must configure SELinux to be in Enforcing mode to run SQL
                   Server as a confined application' in ansible_failed_result.msg
-      # always:
-      #   - name: Clean up after the role invocation
-      #     include_tasks: tasks/cleanup.yml
+      always:
+        - name: Clean up after the role invocation
+          include_tasks: tasks/cleanup.yml


### PR DESCRIPTION
Enhancement: Make the role wait for ha_cluster to finish configuration

Reason: The role does some actions after the `ha_cluster` role finishes, it needs to wait for the `pcs` to finish configuration.

Result: Run the  `crm_resource --wait` command after ha_cluster role finishes.