### PR TITLE
feat: Write lease validity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1030,31 +1030,31 @@ For more information, see the `fedora.linux_system_roles.ha_cluster` role docume
     ha_cluster_sbd_enabled: true
     ha_cluster_cluster_properties:
       - attrs:
-          - name: cluster-recheck-interval
-            value: 2min
-          - name: start-failure-is-fatal
-            value: true
-          - name: stonith-enabled
-            value: true
-          - name: stonith-watchdog-timeout
-            value: 10
+        - name: cluster-recheck-interval
+          value: 2min
+        - name: start-failure-is-fatal
+          value: true
+        - name: stonith-enabled
+          value: true
+        - name: stonith-watchdog-timeout
+          value: 10
     ha_cluster_resource_primitives:
       - id: ag_cluster
         agent: ocf:mssql:ag
         instance_attrs:
           - attrs:
-              - name: ag_name
-                value: "{{ mssql_ha_ag_name }}"
+            - name: ag_name
+              value: "{{ mssql_ha_ag_name }}"
         meta_attrs:
           - attrs:
-              - name: failure-timeout
-                value: 60s
+            - name: failure-timeout
+              value: 60s
       - id: virtualip
         agent: ocf:heartbeat:IPaddr2
         instance_attrs:
           - attrs:
-              - name: ip
-                value: "{{ mssql_ha_virtual_ip }}"
+            - name: ip
+              value: "{{ mssql_ha_virtual_ip }}"
         operations:
           - action: monitor
             attrs:
@@ -1065,10 +1065,10 @@ For more information, see the `fedora.linux_system_roles.ha_cluster` role docume
         promotable: yes
         meta_attrs:
           - attrs:
-              - name: notify
-                value: true
-              - name: on_fail
-                value: demote
+            - name: notify
+              value: true
+            - name: on_fail
+              value: demote
     ha_cluster_constraints_colocation:
       - resource_leader:
           id: ag_cluster-clone
@@ -1126,41 +1126,41 @@ Note that production environments require Pacemaker configured with fencing agen
     ha_cluster_hacluster_password: "p@55w0rD4"
     ha_cluster_cluster_properties:
       - attrs:
-          - name: cluster-recheck-interval
-            value: 2min
-          - name: start-failure-is-fatal
-            value: true
-          - name: stonith-enabled
-            value: true
+        - name: cluster-recheck-interval
+          value: 2min
+        - name: start-failure-is-fatal
+          value: true
+        - name: stonith-enabled
+          value: true
     ha_cluster_resource_primitives:
       - id: vmfence
         agent: stonith:fence_vmware_soap
         instance_attrs:
           - attrs:
-              - name: username
-                value: vmware_Login
-              - name: passwd
-                value: vmware_password
-              - name: ip
-                value: vmware_ip
-              - name: ssl_insecure
-                value: 1
+            - name: username
+              value: vmware_Login
+            - name: passwd
+              value: vmware_password
+            - name: ip
+              value: vmware_ip
+            - name: ssl_insecure
+              value: 1
       - id: ag_cluster
         agent: ocf:mssql:ag
         instance_attrs:
           - attrs:
-              - name: ag_name
-                value: "{{ mssql_ha_ag_name }}"
+            - name: ag_name
+              value: "{{ mssql_ha_ag_name }}"
         meta_attrs:
           - attrs:
-              - name: failure-timeout
-                value: 60s
+            - name: failure-timeout
+              value: 60s
       - id: virtualip
         agent: ocf:heartbeat:IPaddr2
         instance_attrs:
           - attrs:
-              - name: ip
-                value: "{{ mssql_ha_virtual_ip }}"
+            - name: ip
+              value: "{{ mssql_ha_virtual_ip }}"
         operations:
           - action: monitor
             attrs:
@@ -1171,10 +1171,10 @@ Note that production environments require Pacemaker configured with fencing agen
         promotable: yes
         meta_attrs:
           - attrs:
-              - name: notify
-                value: true
-              - name: on_fail
-                value: demote
+            - name: notify
+              value: true
+            - name: on_fail
+              value: demote
     ha_cluster_constraints_colocation:
       - resource_leader:
           id: ag_cluster-clone
@@ -1246,33 +1246,33 @@ This example playbooks sets the `firewall` variables for the `fedora.linux_syste
       - fence-agents-azure-arm
     ha_cluster_cluster_properties:
       - attrs:
-          - name: cluster-recheck-interval
-            value: 2min
-          - name: start-failure-is-fatal
-            value: true
-          - name: stonith-enabled
-            value: true
-          - name: stonith-timeout
+        - name: cluster-recheck-interval
+          value: 2min
+        - name: start-failure-is-fatal
+          value: true
+        - name: stonith-enabled
+          value: true
+        - name: stonith-timeout
             value: 900
     ha_cluster_resource_primitives:
       - id: rsc_st_azure
         agent: stonith:fence_azure_arm
         instance_attrs:
           - attrs:
-              - name: login
-                value: ApplicationID
-              - name: passwd
-                value: servicePrincipalPassword
-              - name: resourceGroup
-                value: resourceGroupName
-              - name: tenantId
-                value: tenantID
-              - name: subscriptionId
-                value: subscriptionID
-              - name: power_timeout
-                value: 240
-              - name: pcmk_reboot_timeout
-                value: 900
+            - name: login
+              value: ApplicationID
+            - name: passwd
+              value: servicePrincipalPassword
+            - name: resourceGroup
+              value: resourceGroupName
+            - name: tenantId
+              value: tenantID
+            - name: subscriptionId
+              value: subscriptionID
+            - name: power_timeout
+              value: 240
+            - name: pcmk_reboot_timeout
+              value: 900
       - id: azure_load_balancer
         agent: azure-lb
         instance_attrs:

--- a/README.md
+++ b/README.md
@@ -1067,6 +1067,8 @@ For more information, see the `fedora.linux_system_roles.ha_cluster` role docume
           - attrs:
               - name: notify
                 value: true
+              - name: on_fail
+                value: demote
     ha_cluster_constraints_colocation:
       - resource_leader:
           id: ag_cluster-clone
@@ -1171,6 +1173,8 @@ Note that production environments require Pacemaker configured with fencing agen
           - attrs:
               - name: notify
                 value: true
+              - name: on_fail
+                value: demote
     ha_cluster_constraints_colocation:
       - resource_leader:
           id: ag_cluster-clone
@@ -1309,6 +1313,8 @@ This example playbooks sets the `firewall` variables for the `fedora.linux_syste
           - attrs:
             - name: notify
               value: true
+            - name: on_fail
+              value: demote
     ha_cluster_constraints_colocation:
       - resource_leader:
           id: ag_cluster-clone

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -979,6 +979,12 @@
 - name: Configure for high availability
   when: mssql_ha_configure | bool
   block:
+    # Required for configure_ag.j2 to set WRITE_LEASE_VALIDITY based on
+    # mssql-server version
+    - name: Get mssql-server version to see if WRITE_LEASE_VALIDITY is available
+      package_facts:
+      no_log: "{{ __mssql_gather_facts_no_log | d(false) }}"
+
     - name: Verify that hosts with mssql_ha_replica_type=primary is available
       assert:
         that: ansible_play_hosts |

--- a/templates/configure_ag.j2
+++ b/templates/configure_ag.j2
@@ -222,7 +222,7 @@ BEGIN
       CLUSTER_TYPE = {{ mssql_ha_ag_cluster_type }},
 {% if ansible_facts.packages['mssql-server'][0]['version']
   is version('15.0.4153.1', '>=') %}
-      WRITE_LEASE_VALIDITY=20
+      WRITE_LEASE_VALIDITY=10
 {% endif %}
     )
     FOR REPLICA ON

--- a/templates/configure_ag.j2
+++ b/templates/configure_ag.j2
@@ -219,7 +219,11 @@ BEGIN
   CREATE AVAILABILITY GROUP {{ mssql_ha_ag_name }}
     WITH (
       DB_FAILOVER = {{ __mssql_ha_db_failover }},
-      CLUSTER_TYPE = {{ mssql_ha_ag_cluster_type }}
+      CLUSTER_TYPE = {{ mssql_ha_ag_cluster_type }},
+{% if ansible_facts.packages['mssql-server'][0]['version']
+  is version('15.0.4153.1', '>=') %}
+      WRITE_LEASE_VALIDITY=20
+{% endif %}
     )
     FOR REPLICA ON
 {# Sort ansible_play_hosts #}

--- a/tests/tests_configure_ha_cluster_external.yml
+++ b/tests/tests_configure_ha_cluster_external.yml
@@ -40,31 +40,31 @@
     ha_cluster_sbd_enabled: true
     ha_cluster_cluster_properties:
       - attrs:
-          - name: cluster-recheck-interval
-            value: 2min
-          - name: start-failure-is-fatal
-            value: true
-          - name: stonith-enabled
-            value: true
-          - name: stonith-watchdog-timeout
-            value: 10
+        - name: cluster-recheck-interval
+          value: 2min
+        - name: start-failure-is-fatal
+          value: true
+        - name: stonith-enabled
+          value: true
+        - name: stonith-watchdog-timeout
+          value: 10
     ha_cluster_resource_primitives:
       - id: ag_cluster
         agent: ocf:mssql:ag
         instance_attrs:
           - attrs:
-              - name: ag_name
-                value: "{{ mssql_ha_ag_name }}"
+            - name: ag_name
+              value: "{{ mssql_ha_ag_name }}"
         meta_attrs:
           - attrs:
-              - name: failure-timeout
-                value: 60s
+            - name: failure-timeout
+              value: 60s
       - id: virtualip
         agent: ocf:heartbeat:IPaddr2
         instance_attrs:
           - attrs:
-              - name: ip
-                value: "{{ mssql_ha_virtual_ip }}"
+            - name: ip
+              value: "{{ mssql_ha_virtual_ip }}"
         operations:
           - action: monitor
             attrs:
@@ -75,10 +75,10 @@
         promotable: true
         meta_attrs:
           - attrs:
-              - name: notify
-                value: true
-              - name: on_fail
-                value: demote
+            - name: notify
+              value: true
+            - name: on_fail
+              value: demote
     ha_cluster_constraints_colocation:
       - resource_leader:
           id: ag_cluster-clone

--- a/tests/tests_configure_ha_cluster_external.yml
+++ b/tests/tests_configure_ha_cluster_external.yml
@@ -77,6 +77,8 @@
           - attrs:
               - name: notify
                 value: true
+              - name: on_fail
+                value: demote
     ha_cluster_constraints_colocation:
       - resource_leader:
           id: ag_cluster-clone


### PR DESCRIPTION
Enhancement: Implement WRITE_LEASE_VALIDITY for HA scenarios

Reason: This feature improves performance of HA configuration

Result: Users must add another meta attribute for ag_cluster resource clone with `on_fail: demote`

