### PR TITLE
fix: Running selinux unconfined is supported with permissive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,9 @@ Whether to manage SELinux.
 
 When set to `true`, configures the following SELinux contexts and settings:
 
-1. SELinux `enforcing` or `permissive` mode based on the value of the [mssql_run_selinux_confined](#mssql_run_selinux_confined) variable.
+1. Ensures the `mssql_port_t` SELinux port type for [mssql_tcp_port](#mssql_tcp_port).
 2. When you define [mssql_datadir](#mssql_datadir) or [mssql_logdir](#mssql_logdir), configures SELinux context `mssql_db_t` for [mssql_datadir](#mssql_datadir) and `mssql_var_t` for [mssql_logdir](#mssql_logdir).
+3. When you set [mssql_ha_configure](#mssql_ha_configure) to `true`, ensures the `mssql_port_t` SELinux port type [mssql_ha_endpoint_port](#mssql_ha_endpoint_port).
 
 Default: `false`
 

--- a/tasks/configure_storage_paths.yml
+++ b/tasks/configure_storage_paths.yml
@@ -24,7 +24,9 @@
       (selinux_fcontexts | default([])) + selinux_fcontext }}"
     selinux_restore_dirs: "{{
       (selinux_restore_dirs | default([])) + selinux_restore_dir }}"
-  when: mssql_manage_selinux | bool
+  when:
+    - mssql_manage_selinux | bool
+    - mssql_run_selinux_confined | bool
 
 - name: Configure the setting {{ __mssql_storage_setting }}
   include_tasks: mssql_conf_setting.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -125,8 +125,19 @@
     - not __mssql_confined_supported
   fail:
     msg: >-
-      mssql_manage_selinux and mssql_run_selinux_confined is supported only on
-      RHEL 9 managed nodes
+      Variables mssql_run_selinux_confined and mssql_manage_selinux are
+      supported only on RHEL 9 managed nodes
+
+- name: Verify that mssql_manage_selinux is set properly
+  when:
+    - mssql_manage_selinux | bool
+    - not mssql_run_selinux_confined
+  fail:
+    msg: >-
+      You set mssql_manage_selinux to true and mssql_run_selinux_confined to
+      false. mssql_manage_selinux is only applicable when
+      mssql_run_selinux_confined is set to true. You must either set both
+      variables to true or to false.
 
 - name: Gather package facts
   package_facts:
@@ -223,43 +234,9 @@
     (mssql_upgrade | bool)
 
 - name: Configure to run as a confined application with SELinux
-  when: __mssql_confined_supported | bool
-  block:
-    - name: Ensure that the system is in SELinux enforcing state
-      when: mssql_manage_selinux | bool
-      include_role:
-        name: fedora.linux_system_roles.selinux
-      vars:
-        selinux_state: "{{
-          mssql_run_selinux_confined | ternary('enforcing', 'permissive') }}"
-
-    - name: Get the current mode of SELinux
-      command: getenforce
-      register: __mssql_getenforce
-      changed_when: false
-
-    - name: Verify that SELinux is in enforcing mode
-      when: mssql_run_selinux_confined | bool
-      assert:
-        that: __mssql_getenforce.stdout == 'Enforcing'
-        fail_msg: >-
-          You must configure SELinux to be in Enforcing mode to run SQL Server
-          as a confined application. You can do this with the role by setting
-          the mssql_manage_selinux variable to true
-
-    - name: Verify that SELinux is not in enforcing mode
-      when: not mssql_run_selinux_confined
-      assert:
-        that: __mssql_getenforce.stdout != 'Enforcing'
-        fail_msg: >-
-          SELinux is in enforcing mode.
-          Set mssql_run_selinux_confined to true to run SQL Server as a confined
-          application to work with SELinux in enforcing mode.
-
-    - name: Ensure the package {{ __mssql_server_selinux_packages }}
-      package:
-        name: "{{ __mssql_server_selinux_packages }}"
-        state: "{{ mssql_run_selinux_confined | ternary('present', 'absent') }}"
+  package:
+    name: "{{ __mssql_server_selinux_packages }}"
+    state: "{{ mssql_run_selinux_confined | ternary('present', 'absent') }}"
 
 - name: Ensure the package {{ __mssql_server_packages }}
   package:
@@ -371,11 +348,14 @@
         setype: mssql_port_t
         state: present
         local: true
-  when: mssql_manage_selinux | bool
+  when:
+    - mssql_manage_selinux | bool
+    - mssql_run_selinux_confined | bool
 
 - name: Ensure correct SELinux context for storage paths and ports
   when:
     - mssql_manage_selinux | bool
+    - mssql_run_selinux_confined | bool
     - >-
       (selinux_fcontexts is defined) or
       (selinux_restore_dirs is defined) or
@@ -977,6 +957,7 @@
         - "{{ ansible_failed_result.stdout_lines }}"
 
 - name: Configure for high availability
+  any_errors_fatal: true
   when: mssql_ha_configure | bool
   block:
     - name: Verify that hosts with mssql_ha_replica_type=primary is available
@@ -1065,7 +1046,6 @@
               {%- endif -%}
 
     - name: Configure availability group on the primary node
-      any_errors_fatal: true
       when: mssql_ha_replica_type == 'primary'
       block:
         - name: Ensure the package {{ __mssql_server_ha_packages }}
@@ -1137,7 +1117,6 @@
     # In the case of fail over the primary replica moves to a different server.
     # This block identifies the current primary replica and works on it.
     - name: Configure availability group on the current primary replica
-      any_errors_fatal: true
       block:
         - name: Get the current primary replica in SQL
           vars:

--- a/tests/tasks/verify_settings.yml
+++ b/tests/tasks/verify_settings.yml
@@ -108,7 +108,12 @@
         "TCP Provider: Error code 0x2749" not in __mssql_test_psw_query.stdout
         and
         "TCP Provider: Error code 0x2749" not in __mssql_test_psw_query.stderr
-
+        and
+        "TCP Provider: Timeout error [258]" not in __mssql_test_psw_query.stdout
+        and
+        "TCP Provider: Timeout error [258]" not in __mssql_test_psw_query.stderr
+      retries: 5
+      delay: 10
 
     - name: Set the mssql_password variable to default null
       set_fact:
@@ -204,22 +209,7 @@
 
 - name: Verify configuration for confined application
   when: __verify_mssql_is_confined is defined
-  block:
-    - name: Get the current mode of SELinux
-      command: getenforce
-      register: __mssql_getenforce
-      changed_when: false
-
-    - name: Verify that SELinux is in the mode {{ __mssql_selinux_mode }}
-      vars:
-        __mssql_selinux_mode: "{{
-          'Enforcing' if __verify_mssql_is_confined
-          else 'Permissive' }}"
-      assert:
-        that: __mssql_getenforce.stdout == __mssql_selinux_mode
-
-    - name: Verify the package {{ __mssql_server_selinux_packages }}
-      include_tasks: verify_package.yml
-      vars:
-        __mssql_verify_package_name: "{{ __mssql_server_selinux_packages }}"
-        __mssql_verify_package_installed: "{{ __verify_mssql_is_confined }}"
+  vars:
+    __mssql_verify_package_name: "{{ __mssql_server_selinux_packages }}"
+    __mssql_verify_package_installed: "{{ __verify_mssql_is_confined }}"
+  include_tasks: verify_package.yml

--- a/tests/tests_configure_ha_cluster_external.yml
+++ b/tests/tests_configure_ha_cluster_external.yml
@@ -16,8 +16,8 @@
       (ansible_distribution in ['CentOS', 'RedHat']) and
       (ansible_distribution_major_version is version('9', '>=')) }}"
     __mssql_gather_facts_no_log: true
-    mssql_manage_selinux: "{{ __mssql_test_confined_supported }}"
-    mssql_run_selinux_confined: "{{ __mssql_test_confined_supported }}"
+    mssql_manage_selinux: false
+    mssql_run_selinux_confined: false
     mssql_ha_configure: true
     mssql_ha_endpoint_port: 5022
     mssql_ha_cert_name: ExampleCert
@@ -214,7 +214,13 @@
                 that: "'Started' in __pcs_status_virtualip.stdout"
 
             - name: Move the virtualip resource
-              command: pcs resource move virtualip
+              command: >-
+                pcs resource move
+                {% if (ansible_distribution in ['CentOS', 'RedHat']) and
+                (ansible_distribution_major_version is version('9', '>=')) %}
+                move-with-constraint
+                {% endif %}
+                virtualip
               register: __pcs_move
               run_once: true
               changed_when: true

--- a/tests/tests_configure_ha_cluster_read_scale.yml
+++ b/tests/tests_configure_ha_cluster_read_scale.yml
@@ -12,7 +12,8 @@
     mssql_version: 2022
     mssql_manage_firewall: true
     __mssql_gather_facts_no_log: true
-    mssql_manage_selinux: "{{ mssql_run_selinux_confined }}"
+    mssql_manage_selinux: false
+    mssql_run_selinux_confined: false
     mssql_ha_configure: true
     mssql_ha_endpoint_port: 5022
     mssql_ha_cert_name: ExampleCert

--- a/tests/tests_selinux_enforcing_2022.yml
+++ b/tests/tests_selinux_enforcing_2022.yml
@@ -30,8 +30,8 @@
         - name: Assert that the role failed with selinux_confined not supported
           assert:
             that: >-
-              'mssql_manage_selinux and mssql_run_selinux_confined is supported
-              only on RHEL 9 managed nodes' in ansible_failed_result.msg
+              'Variables mssql_run_selinux_confined and mssql_manage_selinux are
+              supported only on RHEL 9' in ansible_failed_result.msg
       always:
         - name: Clean up after the role invocation
           include_tasks: tasks/cleanup.yml
@@ -55,26 +55,14 @@
             __verify_mssql_edition: Evaluation
             __verify_mssql_is_confined: true
 
-        - name: While the system is in enforcing, attempt running not confined
-          block:
-            - name: Attempt running not confined
-              include_role:
-                name: linux-system-roles.mssql
-              vars:
-                mssql_manage_selinux: false
-                mssql_run_selinux_confined: false
-          rescue:
-            - name: Assert the role failure with selinux_confined not supported
-              assert:
-                that: >-
-                  'SELinux is in enforcing mode. Set mssql_run_selinux_confined
-                  to true to run SQL Server' in ansible_failed_result.msg
+        - name: Configure the mssql-server service start limit interval and burst
+          include_tasks: tasks/mssql-sever-increase-start-limit.yml
 
         - name: Run without selinux_confined
           include_role:
             name: linux-system-roles.mssql
           vars:
-            mssql_manage_selinux: true
+            mssql_manage_selinux: false
             mssql_run_selinux_confined: false
 
         - name: Verify settings
@@ -83,21 +71,6 @@
             __verify_mssql_password: "p@55w0rD"
             __verify_mssql_edition: Evaluation
             __verify_mssql_is_confined: false
-
-        - name: While the system is in enforcing, attempt running not confined
-          block:
-            - name: Attempt running not confined
-              include_role:
-                name: linux-system-roles.mssql
-              vars:
-                mssql_manage_selinux: false
-                mssql_run_selinux_confined: false
-          rescue:
-            - name: Assert the role failure with selinux_confined not supported
-              assert:
-                that: >-
-                  'You must configure SELinux to be in Enforcing mode to run SQL
-                  Server as a confined application' in ansible_failed_result.msg
       always:
         - name: Clean up after the role invocation
           include_tasks: tasks/cleanup.yml


### PR DESCRIPTION
Enhancement: Add support for running SQL Server as a SELinux unconfined application with SELinux in enforcing mode on RHEL 9

Reason: This support was added by Microsoft

Result: Now you can run SQL Server as an unconfined application on RHEL 9 in the default enforcing SELinux mode