### PR TITLE
test: fix pcs resource move/move-with-constraint logic

### DIFF
--- a/tests/tests_configure_ha_cluster_external.yml
+++ b/tests/tests_configure_ha_cluster_external.yml
@@ -215,10 +215,12 @@
 
             - name: Move the virtualip resource
               command: >-
-                pcs resource move
+                pcs resource
                 {% if (ansible_distribution in ['CentOS', 'RedHat']) and
                 (ansible_distribution_major_version is version('9', '>=')) %}
                 move-with-constraint
+                {% else %}
+                move
                 {% endif %}
                 virtualip
               register: __pcs_move


### PR DESCRIPTION
Enhancement: Fix tests_configure_ha_cluster_external.yml

Reason:  Due to a bug RHEL 9 executed `pcs resource move move-with-constraint` instead of `pcs resource move-with-constraint`

Result:  Test executes `pcs resource move-with-constraint` on RHEL 9 
