### PR TITLE
ci: tox-lsr 3.4.0 - fix py27 tests; move other checks to py310

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Convert role to collection format
         run: |

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: MIT
 ---
-extends: default
 ignore: |
   /.tox/

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -787,7 +787,7 @@
           else 'private' }}/{{ item | basename }}
         owner: mssql
         group: mssql
-        mode: 0600
+        mode: "0600"
         force: "{{ mssql_tls_force }}"
       with_items:
         - "{{ mssql_tls_cert }}"
@@ -990,7 +990,7 @@
             path: "{{ __mssql_keytab_path }}"
             owner: mssql
             group: mssql
-            mode: 0440
+            mode: "0440"
           notify: Restart the mssql-server service
 
     - name: Fetch keytab file to host
@@ -1001,7 +1001,7 @@
         dest: "{{ __mssql_keytab_path }}"
         owner: mssql
         group: mssql
-        mode: 0440
+        mode: "0440"
 
     - name: Configure the network.kerberoskeytabfile setting
       include_tasks: mssql_conf_setting.yml
@@ -1309,7 +1309,7 @@
             dest: "{{ item.value }}"
             owner: mssql
             group: mssql
-            mode: 0660
+            mode: "0660"
             force: true
           with_dict:
             cert: "{{ __mssql_ha_cert_dest }}"
@@ -1366,7 +1366,7 @@
             dest: /var/opt/mssql/secrets/passwd
             owner: root
             group: root
-            mode: 0400
+            mode: "0400"
             force: true
           no_log: true
 

--- a/tests/tests_configure_ha_cluster_external.yml
+++ b/tests/tests_configure_ha_cluster_external.yml
@@ -677,7 +677,7 @@
                 remote_src: true
                 src: "{{ item }}"
                 dest: /tmp/{{ item | basename }}
-                mode: 0600
+                mode: "0600"
               loop:
                 - "{{ __mssql_ha_cert_dest }}"
                 - "{{ __mssql_ha_private_key_dest }}"
@@ -718,7 +718,7 @@
                 remote_src: true
                 src: /tmp/{{ __mssql_ha_private_key_dest | basename }}
                 dest: "{{ __mssql_ha_private_key_dest }}"
-                mode: 0600
+                mode: "0600"
 
             - name: Input create_and_back_up_cert.j2
               vars:
@@ -746,7 +746,7 @@
                 remote_src: true
                 src: /tmp/{{ __mssql_ha_cert_dest | basename }}
                 dest: "{{ __mssql_ha_cert_dest }}"
-                mode: 0600
+                mode: "0600"
 
             - name: Drop certificate from SQL Server
               vars:


### PR DESCRIPTION
The latest version of virtualenv does not support creating
python 2.7 virtualenvs.  Change our CI tests to restrict the version
of virtualenv<20.22.0 and tox<4.15 for py27 environments

Move pylint, flake8, and black checks to the py310 environment
which is currently supported by ansible-core 2.17 and its related
checkers such as ansible-lint and ansible-test

pylint now uses ansible-core 2.17 and restricts the version of
pylint to 3.1.0 which is the version used by ansible-test 2.17

Remove `extends: default` for .yamllint.yml.  The latest version
of ansible-lint will automatically incorporate local yamllint
settings unless there is an `extends:`.

The above changes require some fixes to the role code.

For more information, see
https://github.com/linux-system-roles/tox-lsr/pull/168
and
https://github.com/linux-system-roles/tox-lsr/pull/170

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
