### PR TITLE
tests:  In HA tests, revert mssql_run_selinux_confined: true on EL 9

### DIFF
--- a/tests/tests_configure_ha_cluster_external.yml
+++ b/tests/tests_configure_ha_cluster_external.yml
@@ -25,11 +25,8 @@
     mssql_version: 2022
     mssql_manage_firewall: true
     __mssql_gather_facts_no_log: true
-    __mssql_test_confined_supported: "{{
-      (ansible_distribution in ['CentOS', 'RedHat']) and
-      (ansible_distribution_major_version is version('9', '>=')) }}"
-    mssql_manage_selinux: "{{ __mssql_test_confined_supported }}"
-    mssql_run_selinux_confined: "{{ __mssql_test_confined_supported }}"
+    mssql_manage_selinux: false
+    mssql_run_selinux_confined: false
     mssql_ha_configure: true
     mssql_ha_endpoint_port: 5022
     mssql_ha_cert_name: ExampleCert

--- a/tests/tests_configure_ha_cluster_read_scale.yml
+++ b/tests/tests_configure_ha_cluster_read_scale.yml
@@ -24,11 +24,8 @@
     mssql_version: 2022
     mssql_manage_firewall: true
     __mssql_gather_facts_no_log: true
-    __mssql_test_confined_supported: "{{
-      (ansible_distribution in ['CentOS', 'RedHat']) and
-      (ansible_distribution_major_version is version('9', '>=')) }}"
-    mssql_manage_selinux: "{{ __mssql_test_confined_supported }}"
-    mssql_run_selinux_confined: "{{ __mssql_test_confined_supported }}"
+    mssql_manage_selinux: false
+    mssql_run_selinux_confined: false
     mssql_ha_configure: true
     mssql_ha_endpoint_port: 5022
     mssql_ha_cert_name: ExampleCert


### PR DESCRIPTION
Enhancement: In HA tests, revert mssql_run_selinux_confined: true on EL 9

Reason: RHEL 9 with selinux-confined mode doesn't support HA scenario due to SELinux denies on mssql-server side
