### PR TITLE
fix: Retry waiting for pacemaker with `crm_resource --wait`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1396,6 +1396,8 @@
           command: crm_resource --wait
           changed_when: false
           when: mssql_manage_ha_cluster | bool
+          register: __mssql_crm_resource_wait
+          until: __mssql_crm_resource_wait is success
 
     # Configure on a current primary identified above
     - name: Configure listener for the availability group {{ mssql_ha_ag_name }}

--- a/tests/tests_configure_ha_cluster_external.yml
+++ b/tests/tests_configure_ha_cluster_external.yml
@@ -186,6 +186,8 @@
               command: crm_resource --wait
               changed_when: false
               when: mssql_manage_ha_cluster | bool
+              register: __mssql_crm_resource_wait
+              until: __mssql_crm_resource_wait is success
 
             - name: Get global pcs status
               command: pcs status
@@ -229,6 +231,8 @@
               command: crm_resource --wait
               changed_when: false
               when: mssql_manage_ha_cluster | bool
+              register: __mssql_crm_resource_wait
+              until: __mssql_crm_resource_wait is success
 
             - name: Get global pcs status
               command: pcs status resources


### PR DESCRIPTION
Enhancement: Retry waiting for pacemaker with `crm_resource --wait`

Reason: The command `crm_resource --wait` might fail when pacemaker is not started yet. Adding a retry with 1s delay between retries fixes this.