### PR TITLE
feat: Use new adutil functionality to enable AES encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -885,7 +885,7 @@ Type: `string`
 
 Whether to run the `fedora.linux_system_roles.ha_cluster` role from this role.
 
-Note that the `fedora.linux_system_roles.ha_cluster` role has the following limitation:
+Note that the `fedora.linux_system_roles.ha_cluster` role has the following limitations:
 
 * This role replaces the configuration of HA Cluster on specified nodes.
   Any settings not specified in the role variables will be lost.
@@ -1341,6 +1341,9 @@ This example playbooks sets the `firewall` variables for the `fedora.linux_syste
 
 Optional: Use variables starting with the `mssql_ad_` prefix to configure SQL Server to authenticate with Microsoft AD Server.
 
+Note that creating users in Active Directory is not idempotent - it always return changed status.
+This is because the `adutil` tool is not able to return statuses of users, hence the role must force-configure users.
+
 ### AD Considerations
 
 This role uses the `fedora.linux_system_roles.ad_integration` role to join SQL Server with AD server.
@@ -1370,23 +1373,8 @@ For more information, see [Join SQL Server on a Linux host to an Active Director
 
 ### Finishing AD Server Configuration
 
-1. After you execute the role to configure AD Server authentication, you must complete one of the following procedures to add AES128 and AES256 kerberos encryption types to the [mssql_ad_sql_user](#mssql_ad_sql_user) on AD Server.
-
-    * For the RSAT UI users, complete the following steps:
-        1. Launch **Active Directory Users and Computers**
-        2. Navigate to the SQL User (Default: ***domain*** > **Users** > ***sqluser***)
-        3. Right click the SQL User account and select **Properties**
-        4. In the **Account** tab, select **This account supports Kerberos AES 128 bit encryption** and **This account supports Kerberos AES 256 bit encryption**
-        5. Click **Apply**
-
-    * For the PowerShell users, enter the following command:
-
-        ```powershell
-        Set-ADUser -Identity <sqluser> -KerberosEncryptionType AES128,AES256
-        ```
-
-2. You must create Active Directory-based logins in Transact-SQL as described in [Create Active Directory-based SQL Server logins in Transact-SQL](https://learn.microsoft.com/en-us/sql/linux/sql-server-linux-ad-auth-adutil-tutorial?view=sql-server-ver16#create-active-directory-based-sql-server-logins-in-transact-sql) in *Tutorial: Use adutil to configure Active Directory authentication with SQL Server on Linux* in Microsoft documentation.
-You can write a T-SQL script and input it as described in [mssql_post_input_sql_file](#inputting-sql-scripts-to-sql-server). See example playbooks for how to create logins using the `mssql_post_input_sql_content` variable.
+* You must create Active Directory-based logins in Transact-SQL as described in [Create Active Directory-based SQL Server logins in Transact-SQL](https://learn.microsoft.com/en-us/sql/linux/sql-server-linux-ad-auth-adutil-tutorial?view=sql-server-ver16#create-active-directory-based-sql-server-logins-in-transact-sql) in *Tutorial: Use adutil to configure Active Directory authentication with SQL Server on Linux* in Microsoft documentation.
+  You can write a T-SQL script and input it as described in [mssql_post_input_sql_file](#inputting-sql-scripts-to-sql-server). See example playbooks for how to create logins using the `mssql_post_input_sql_content` variable.
 
 ### Verifying Authentication
 
@@ -1499,6 +1487,7 @@ Type: `bool`
 #### mssql_ad_sql_user
 
 User to be created in SQL Server and used for authentication.
+The role configures this user with `Kerberos AES 128 bit encryption` and `Kerberos AES 256 bit encryption` enabled.
 
 Default: `null`
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -853,7 +853,7 @@
         - name: Ensure adutil and krb5-workstation
           package:
             name:
-              - adutil
+              - adutil >= 1.1.143-1
               - krb5-workstation
             state: present
 
@@ -905,6 +905,18 @@
           register: __mssql_adutil_user_create
           when: not __mssql_adutil_account_exists.stdout | bool
           no_log: true
+          changed_when: true
+
+        # adutil cli doesn't provide functionality to get info about user
+        # configuration, hence need to force set it not idempotently
+        - name: Ensure proper configuration on user {{ mssql_ad_sql_user }}
+          command: >-
+            adutil user modify
+            --name {{ mssql_ad_sql_user }}
+            --distname {{ mssql_ad_sql_user_dn | quote }}
+            --enableaessupport
+            --debug
+          when: __mssql_adutil_user_create is not changed
           changed_when: true
 
         - name: Get SPNs for the principal {{ mssql_ad_sql_user }}

--- a/tests/playbooks/tests_ad_integration_join_false.yml
+++ b/tests/playbooks/tests_ad_integration_join_false.yml
@@ -62,22 +62,25 @@
       END
 
   tasks:
-    # Test general scenario
-    - name: Set up MSSQL and configure AD authentication
+    # Test with mssql_ad_join: false
+    - name: Authenticate to AD
+      include_role:
+        name: linux-system-roles.ad_integration
+
+    - name: Set up MSSQL and configure AD authentication without joining to AD
       include_role:
         name: linux-system-roles.mssql
+      vars:
+        mssql_ad_join: false
+        # Explicitly set kerberos vars, otherwise the value becomes null
+        mssql_ad_kerberos_user: Administrator
+        mssql_ad_kerberos_password: Secret123
+        ad_integration_user: null
+        ad_integration_password: null
+        ad_integration_manage_dns: null
+        ad_integration_dns_server: null
+        ad_integration_dns_connection_name: null
+        ad_integration_dns_connection_type: null
 
     - name: Test AD integration
       include_tasks: ../tasks/verify_ad_auth.yml
-
-    # Test with mssql_ad_keytab_file
-    - name: Fetch keytab file that was prepared above
-      fetch:
-        src: /var/opt/mssql/secrets/mssql.keytab
-        dest: /tmp/mssql.keytab
-        flat: true
-        mode: preserve
-      run_once: true
-
-    - name: Clean up after the role invocation
-      include_tasks: ../tasks/cleanup.yml

--- a/tests/playbooks/tests_ad_integration_w_keytab.yml
+++ b/tests/playbooks/tests_ad_integration_w_keytab.yml
@@ -62,22 +62,17 @@
       END
 
   tasks:
-    # Test general scenario
-    - name: Set up MSSQL and configure AD authentication
+    - name: Set up MSSQL and configure AD authentication with keytab
+      vars:
+        # /tmp/mssql.keytab is created in tests_ad_integration.yml
+        mssql_ad_keytab_file: /tmp/mssql.keytab
+        mssql_ad_keytab_remote_src: false
+        mssql_ad_sql_password: null
       include_role:
         name: linux-system-roles.mssql
 
     - name: Test AD integration
       include_tasks: ../tasks/verify_ad_auth.yml
-
-    # Test with mssql_ad_keytab_file
-    - name: Fetch keytab file that was prepared above
-      fetch:
-        src: /var/opt/mssql/secrets/mssql.keytab
-        dest: /tmp/mssql.keytab
-        flat: true
-        mode: preserve
-      run_once: true
 
     - name: Clean up after the role invocation
       include_tasks: ../tasks/cleanup.yml


### PR DESCRIPTION
Enhancement: Use new adutil functionality to enable AES encryption

Reason: Since adutil version 1.1.83, adutil supports enabling Kerberos AES 128 and AES 256 bit encryption when creating and modifying the user.

Result: The role automates enabling Kerberos AES 128 and AES 256 bit encryption, so the manual post-configuration task  is not required.
