### PR TITLE
feat: Add support for Fedora

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -26,6 +26,7 @@ galaxy_info:
     - el7
     - el8
     - el9
+    - fedora
     - fedora35
     - microsoft
     - mssql

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -300,16 +300,16 @@
     name: "{{ __mssql_server_packages }}"
     state: "{{ 'latest' if mssql_upgrade else 'present' }}"
 
-# /opt/mssql/bin/sqlservr requires libldap-2.4.so.2. Latest Fedora use newer
-# libldap by default, therefore, it is required to install openldap-compat
-# because it provides libldap-2.4.so.2.
-- name: Ensure that the openldap-compat package is installed
-  package:
-    name: openldap-compat
-    state: present
-  when:
-    - ansible_distribution == "Fedora"
-    - ansible_distribution_version | int >= 34
+# # /opt/mssql/bin/sqlservr requires libldap-2.4.so.2. Latest Fedora use newer
+# # libldap by default, therefore, it is required to install openldap-compat
+# # because it provides libldap-2.4.so.2.
+# - name: Ensure that the openldap-compat package is installed
+#   package:
+#     name: openldap-compat
+#     state: present
+#   when:
+#     - ansible_distribution == "Fedora"
+#     - ansible_distribution_version | int >= 34
 
 - name: Check if the errorlog file exists and its location
   shell: |

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -300,17 +300,6 @@
     name: "{{ __mssql_server_packages }}"
     state: "{{ 'latest' if mssql_upgrade else 'present' }}"
 
-# # /opt/mssql/bin/sqlservr requires libldap-2.4.so.2. Latest Fedora use newer
-# # libldap by default, therefore, it is required to install openldap-compat
-# # because it provides libldap-2.4.so.2.
-# - name: Ensure that the openldap-compat package is installed
-#   package:
-#     name: openldap-compat
-#     state: present
-#   when:
-#     - ansible_distribution == "Fedora"
-#     - ansible_distribution_version | int >= 34
-
 - name: Check if the errorlog file exists and its location
   shell: |
     set -euo pipefail

--- a/tests/tasks/assert_fail_on_unsupported_ver.yml
+++ b/tests/tasks/assert_fail_on_unsupported_ver.yml
@@ -8,8 +8,10 @@
     (ansible_distribution in ['CentOS', 'RedHat'] and
     ansible_distribution_major_version is version('7', '=') and
     mssql_version | int == 2022) or
-    (ansible_distribution in ['CentOS', 'RedHat'] and
-    ansible_distribution_major_version is version('9', '=') and
+    ((ansible_distribution in ['CentOS', 'RedHat'] and
+    ansible_distribution_major_version is version('9', '=')) or
+    (ansible_distribution in ['Fedora'])
+    and
     mssql_version | int != 2022)
   block:
     - name: Run the role

--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -41,12 +41,6 @@
   command: kdestroy -A
   when: ansible_facts.packages["krb5-workstation"] is defined
 
-- name: Ensure that yum and dnf caching is enabled
-  lineinfile:
-    path: /etc/yum.conf
-    regexp: '^keepcache='
-    line: keepcache=1
-
 - name: Remove related packages
   package:
     name:

--- a/tests/tests_accept_eula.yml
+++ b/tests/tests_accept_eula.yml
@@ -7,11 +7,13 @@
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: "{{
-      '2022' if ansible_distribution_major_version is version('9', '>=')
+      '2022' if (ansible_distribution_major_version is version('9', '>=') or
+      ansible_distribution in ['Fedora'])
       else '2017' }}"
     __mssql_test_confined_supported: "{{
-      (ansible_distribution in ['CentOS', 'RedHat']) and
-      (ansible_distribution_major_version is version('9', '>=')) }}"
+      ((ansible_distribution in ['CentOS', 'RedHat']) and
+      (ansible_distribution_major_version is version('9', '>='))) or
+      (ansible_distribution in ['Fedora']) }}"
     mssql_manage_selinux: "{{ __mssql_test_confined_supported }}"
     mssql_run_selinux_confined: "{{ __mssql_test_confined_supported }}"
     __mssql_gather_facts_no_log: true

--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -53,13 +53,16 @@
             mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
             mssql_accept_microsoft_sql_server_standard_eula: true
             mssql_version: "{{
-              '2022' if ansible_distribution_major_version is version('9', '>=')
+              '2022' if (ansible_distribution_major_version
+              is version('9', '>=') or
+              ansible_distribution in ['Fedora'])
               else '2017' }}"
             mssql_password: P@55w0rD
             mssql_edition: Evaluation
             __mssql_test_confined_supported: "{{
-              (ansible_distribution in ['CentOS', 'RedHat']) and
-              (ansible_distribution_major_version is version('9', '>=')) }}"
+              ((ansible_distribution in ['CentOS', 'RedHat']) and
+              (ansible_distribution_major_version is version('9', '>='))) or
+              (ansible_distribution in ['Fedora']) }}"
             mssql_manage_selinux: "{{ __mssql_test_confined_supported }}"
             mssql_run_selinux_confined: "{{ __mssql_test_confined_supported }}"
       always:


### PR DESCRIPTION
Enhancement: Add support for Fedora

Reason: SQL Server from RHEL 9 RPMs might work on latest Fedora.
