### PR TITLE
chore: Deprecate mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,14 @@ These variables apply to general SQL Server configuration.
 
 ### General Settings Variables
 
-#### mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula
+#### mssql_accept_microsoft_odbc_driver_for_sql_server_eula
 
-Set this variable to `true` to indicate that you accept EULA for installing the `msodbcsql17` package.
+Set this variable to `true` to indicate that you accept EULA for installing  packages `msodbcsql17`, `msodbcsql18`.
 
-The license terms for this product can be downloaded from <https://aka.ms/odbc17eula> and found in `/usr/share/doc/msodbcsql17/LICENSE.txt`.
+The license terms for this product can be found in the following places:
+
+* For version 17, online at <https://aka.ms/odbc17eula> and locally in `/usr/share/doc/msodbcsql17/LICENSE.txt`.
+* For version 18, online at <https://aka.ms/odbc18eula> and locally in `/usr/share/doc/msodbcsql18/LICENSE.txt`.
 
 Default: `false`
 
@@ -146,7 +149,7 @@ This example playbook shows how to use the role to configure SQL Server with the
 ```yaml
 - hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2019
@@ -238,7 +241,7 @@ Run the following playbook against a RHEL 9 system role to configure SQL Server 
 ```yaml
 - hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2022
@@ -311,7 +314,7 @@ Type: `bool`
 ```yaml
 - hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2019
@@ -519,7 +522,7 @@ This example shows how to use the role to configure SQL Server, configure it wit
 ```yaml
 - hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2019
@@ -642,7 +645,7 @@ Certificate files `mycert.pem` and `mykey.key` must exist on the primary node.
 ```yaml
 - hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2019
@@ -665,7 +668,7 @@ This example shows how to use the role to configure SQL Server and configure it 
 ```yaml
 - hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2019
@@ -1000,7 +1003,7 @@ Playbook:
 ```yaml
 - hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2022
@@ -1035,7 +1038,7 @@ For more information, see the `fedora.linux_system_roles.ha_cluster` role docume
 ```yaml
 - hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2019
@@ -1130,7 +1133,7 @@ Note that production environments require Pacemaker configured with fencing agen
 ```yaml
 - hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2019
@@ -1244,7 +1247,7 @@ This example playbooks sets the `firewall` variables for the `fedora.linux_syste
 ```yaml
 - hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2019
@@ -1571,7 +1574,7 @@ Type: `string`
 - name: Configure with AD server authentication
   hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2022
@@ -1613,7 +1616,7 @@ If you received a pre-created keytab file and want the role to use it, set varia
 - name: Configure with AD server authentication with a pre-created keytab file
   hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2022
@@ -1655,7 +1658,7 @@ You must join managed host to AD Server yourself prior to running this playbook.
 - name: Configure with AD server authentication without joining to AD
   hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2022

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 ---
-mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: false
+mssql_accept_microsoft_odbc_driver_for_sql_server_eula: false
 mssql_accept_microsoft_cli_utilities_for_sql_server_eula: false
 mssql_accept_microsoft_sql_server_standard_eula: false
 mssql_version: null

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,6 +66,25 @@
       set_fact:
         mssql_manage_ha_cluster: "{{ mssql_ha_cluster_run_role }}"
 
+- name: >-
+    Link the deprecated
+    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula fact
+  when: mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula is defined
+  block:
+    - name: Print that variable is deprecated
+      debug:
+        msg: >-
+          The variable
+          mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula
+          is deprecated and will be removed in a future version.
+          Edit your playbook to use new variable
+          mssql_accept_microsoft_odbc_driver_for_sql_server_eula
+
+    - name: Link the deprecated fact
+      set_fact:
+        mssql_accept_microsoft_odbc_driver_for_sql_server_eula: "{{
+          mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula }}"
+
 - name: Fail on RHEL or CentOS 10 because it's not supported
   fail:
     msg: This role does not support running against RHEL or CentOS 10 hosts
@@ -76,12 +95,12 @@
 - name: Verify that the user accepts EULA variables
   assert:
     that:
-      - mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula | bool
+      - mssql_accept_microsoft_odbc_driver_for_sql_server_eula | bool
       - mssql_accept_microsoft_cli_utilities_for_sql_server_eula | bool
       - mssql_accept_microsoft_sql_server_standard_eula | bool
     fail_msg:
       - "You must accept EULA by setting the following variables to true:"
-      - "mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula"
+      - "mssql_accept_microsoft_odbc_driver_for_sql_server_eula"
       - "mssql_accept_microsoft_cli_utilities_for_sql_server_eula"
       - "mssql_accept_microsoft_sql_server_standard_eula"
 

--- a/tests/playbooks/tests_ad_integration.yml
+++ b/tests/playbooks/tests_ad_integration.yml
@@ -22,7 +22,7 @@
 - name: Test integration with AD server
   hosts: client
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2022

--- a/tests/playbooks/tests_ad_integration_join_false.yml
+++ b/tests/playbooks/tests_ad_integration_join_false.yml
@@ -22,7 +22,7 @@
 - name: Test integration with AD server
   hosts: client
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2022

--- a/tests/playbooks/tests_ad_integration_w_keytab.yml
+++ b/tests/playbooks/tests_ad_integration_w_keytab.yml
@@ -22,7 +22,7 @@
 - name: Test integration with AD server
   hosts: client
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2022

--- a/tests/tests_2019_upgrade.yml
+++ b/tests/tests_2019_upgrade.yml
@@ -3,7 +3,7 @@
 - name: Ensure that the role installs version 2017 and upgrades to 2019
   hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     __mssql_gather_facts_no_log: true

--- a/tests/tests_2022_upgrade.yml
+++ b/tests/tests_2022_upgrade.yml
@@ -3,7 +3,7 @@
 - name: Ensure that the role installs version 2017 and upgrades to 2019
   hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     __mssql_gather_facts_no_log: true

--- a/tests/tests_accept_eula.yml
+++ b/tests/tests_accept_eula.yml
@@ -3,7 +3,7 @@
 - name: Ensure that the role runs when EULA are accepted
   hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: "{{

--- a/tests/tests_configure_ha_cluster_external.yml
+++ b/tests/tests_configure_ha_cluster_external.yml
@@ -17,7 +17,7 @@
   vars:
     __mssql_single_node_test: "{{ ansible_play_hosts_all | length == 1 }}"
     mssql_debug: true
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_password: "p@55w0rD"

--- a/tests/tests_configure_ha_cluster_read_scale.yml
+++ b/tests/tests_configure_ha_cluster_read_scale.yml
@@ -16,7 +16,7 @@
   hosts: all
   vars:
     mssql_debug: true
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_password: "p@55w0rD"

--- a/tests/tests_idempotency_2017.yml
+++ b/tests/tests_idempotency_2017.yml
@@ -4,7 +4,7 @@
   hosts: all
   gather_facts: false
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2017

--- a/tests/tests_idempotency_2019.yml
+++ b/tests/tests_idempotency_2019.yml
@@ -4,7 +4,7 @@
   hosts: all
   gather_facts: false
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2019

--- a/tests/tests_idempotency_2022.yml
+++ b/tests/tests_idempotency_2022.yml
@@ -4,7 +4,7 @@
   hosts: all
   gather_facts: false
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2022

--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -49,7 +49,7 @@
             name: caller
           vars:
             roletoinclude: linux-system-roles.mssql
-            mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+            mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
             mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
             mssql_accept_microsoft_sql_server_standard_eula: true
             mssql_version: "{{

--- a/tests/tests_input_sql_file_2017.yml
+++ b/tests/tests_input_sql_file_2017.yml
@@ -3,7 +3,7 @@
 - name: Ensure that the role can input sql files to MSSQL
   hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_debug: true

--- a/tests/tests_input_sql_file_2019.yml
+++ b/tests/tests_input_sql_file_2019.yml
@@ -3,7 +3,7 @@
 - name: Ensure that the role can input sql files to MSSQL
   hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_debug: true

--- a/tests/tests_input_sql_file_2022.yml
+++ b/tests/tests_input_sql_file_2022.yml
@@ -3,7 +3,7 @@
 - name: Ensure that the role can input sql files to MSSQL
   hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_debug: true

--- a/tests/tests_password_2017.yml
+++ b/tests/tests_password_2017.yml
@@ -3,7 +3,7 @@
 - name: Ensure that the role is idempotent when changing the sa user password
   hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2017

--- a/tests/tests_password_2019.yml
+++ b/tests/tests_password_2019.yml
@@ -3,7 +3,7 @@
 - name: Ensure that the role is idempotent when changing the sa user password
   hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2019

--- a/tests/tests_password_2022.yml
+++ b/tests/tests_password_2022.yml
@@ -3,7 +3,7 @@
 - name: Ensure that the role is idempotent when changing the sa user password
   hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2022

--- a/tests/tests_selinux_enforcing_2022.yml
+++ b/tests/tests_selinux_enforcing_2022.yml
@@ -4,7 +4,7 @@
   hosts: all
   gather_facts: false
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2022

--- a/tests/tests_tcp_firewall_2017.yml
+++ b/tests/tests_tcp_firewall_2017.yml
@@ -3,7 +3,7 @@
 - name: Verify the use of the firewall role to configure SQL Server TCP ports
   hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_manage_firewall: true

--- a/tests/tests_tcp_firewall_2019.yml
+++ b/tests/tests_tcp_firewall_2019.yml
@@ -3,7 +3,7 @@
 - name: Verify the use of the firewall role to configure SQL Server TCP ports
   hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_manage_firewall: true

--- a/tests/tests_tcp_firewall_2022.yml
+++ b/tests/tests_tcp_firewall_2022.yml
@@ -3,7 +3,7 @@
 - name: Verify the use of the firewall role to configure SQL Server TCP ports
   hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_manage_firewall: true

--- a/tests/tests_tls_2017.yml
+++ b/tests/tests_tls_2017.yml
@@ -3,7 +3,7 @@
 - name: Ensure that tls encryption configuration works
   hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_password: "p@55w0rD"

--- a/tests/tests_tls_2019.yml
+++ b/tests/tests_tls_2019.yml
@@ -3,7 +3,7 @@
 - name: Ensure that tls encryption configuration works
   hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_password: "p@55w0rD"

--- a/tests/tests_tls_2022.yml
+++ b/tests/tests_tls_2022.yml
@@ -3,7 +3,7 @@
 - name: Ensure that tls encryption configuration works
   hosts: all
   vars:
-    mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_password: "p@55w0rD"


### PR DESCRIPTION
Enhancement: Deprecate this variable to use a variable without a version number instead. The role now can install versions 17 and 18.

Reason: After adding `mssql_tools_versions`, this role is able to install odbc driver for mssql_tools 17 and 18. This update changes the variable for specific version 17 to be general.

Result: When users use the deprecated variable `mssql_accept_microsoft_odbc_driver_17_for_sql_server_eula`, the role notifies them to use the new variable, but continues to execute.