### PR TITLE
feat: Add ` mssql_ha_ag_is_contained` and `mssql_ha_ag_reuse_system_db`

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,6 +864,28 @@ Default: `[]`
 
 Type: `list`
 
+#### mssql_ha_ag_is_contained
+
+Whether to configure the availability group provided with [mssql_ha_ag_name](#mssql_ha_ag_name) as contained.
+
+This is supported since SQL Server version 2022.
+
+Default: `false`
+
+Type: `bool`
+
+#### mssql_ha_ag_reuse_system_db
+
+Only applicable when [mssql_ha_ag_is_contained](#mssql_ha_ag_is_contained) is true.
+
+Whether to configure the availability group provided with [mssql_ha_ag_name](#mssql_ha_ag_name) with the reuse_system_db setting.
+
+This is supported since SQL Server version 2022.
+
+Default: `false`
+
+Type: `bool`
+
 ### Configuring Pacemaker Variables
 
 With these variables, you can specify whether to configure Pacemaker HA solution and its configuration.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,6 +52,9 @@ mssql_ha_reset_cert: false
 mssql_ha_endpoint_name: null
 mssql_ha_ag_name: null
 mssql_ha_db_names: []
+mssql_ha_ag_is_contained: false
+# if mssql_ha_ag_is_contained=false, mssql_ha_ag_reuse_system_db will be false
+mssql_ha_ag_reuse_system_db: false
 
 mssql_ha_prep_for_pacemaker: "{{ mssql_ha_ag_cluster_type | lower != 'none' }}"
 mssql_ha_virtual_ip: null

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,9 +5,10 @@
 
 # This is required to prevent the role from using a __mssql_sqlcmd_login_cmd
 # variable value from a previous role invocation
-- name: Unset the __mssql_sqlcmd_login_cmd fact
+- name: Unset internal role facts
   set_fact:
     __mssql_sqlcmd_login_cmd: null
+    __mssql_is_active: null
 
 - name: Link the deprecated mssql_input_sql_file fact
   when: mssql_input_sql_file is defined
@@ -165,6 +166,28 @@
       mssql_run_selinux_confined is set to true. You must either set both
       variables to true or to false.
 
+- name: Verify that mssql_ha_ag_is_contained is not provided with version 2017
+  when:
+    - mssql_ha_ag_is_contained | bool
+    - mssql_version is version('2022', '<')
+  fail:
+    msg: >-
+      mssql_ha_ag_is_contained is not supported on SQL Server < 2022.
+      SQL Server 2019 and greater supports mssql_ha_ag_is_contained.
+      You must either upgrade to a greater version or set
+      mssql_ha_ag_is_contained to false.
+
+- name: Verify fail reuse_system_db=true is not provided without ag_is_contained
+  when:
+    - not mssql_ha_ag_is_contained
+    - mssql_ha_ag_reuse_system_db | bool
+  fail:
+    msg: >-
+      mssql_ha_ag_reuse_system_db is not appilcable when
+      mssql_ha_ag_is_contained = false. You must either set
+      mssql_ha_ag_reuse_system_db to false or set mssql_ha_ag_is_contained
+      to true.
+
 - name: Gather package facts
   package_facts:
   no_log: "{{ __mssql_gather_facts_no_log | d(false) }}"
@@ -177,6 +200,19 @@
     - ansible_facts.packages["mssql-server"][0]["version"].split(".")
       | first | int == item.value
   with_dict: "{{ __mssql_version_package_mapping }}"
+
+- name: >-
+    Verify if mssql_version is not bigger then the existing SQL Server version
+  fail:
+    msg: >-
+      You set mssql_version to {{ mssql_version }}, but your SQL Server is
+      version {{ __mssql_current_version }}. You must either set mssql_upgrade
+      to true to upgrade or not set the mssql_version variable"
+  when:
+    - not mssql_upgrade
+    - mssql_version is not none
+    - __mssql_current_version is defined
+    - mssql_version | int > __mssql_current_version | int
 
 - name: Set mssql_version variable if user does not define it
   set_fact:
@@ -1086,21 +1122,30 @@
         - "{{ ansible_failed_result.stdout_lines }}"
 
 - name: Configure for high availability
-  any_errors_fatal: true
   when: mssql_ha_configure | bool
   block:
-    - name: Verify that hosts with mssql_ha_replica_type=primary is available
-      assert:
-        that: ansible_play_hosts |
-            map('extract', hostvars, 'mssql_ha_replica_type') |
-            select('match', '^primary$') |
-            list |
-            length == 1
-        fail_msg:
-          - Host with mssql_ha_replica_type=primary failed earlier in the play.
-          - Therefore, it is not possible to configure for high availability.
-          - Fix the above error on the primary replica and re-run the role.
+    - name: Mark active hosts
+      set_fact:
+        __mssql_is_active: true
+
+    - name: Fail if any hosts are no longer active
       run_once: true
+      vars:
+        hostvars_list: "{{ ansible_play_hosts_all | map('extract', hostvars) | list }}"
+        active_hosts: >-
+          {{ hostvars_list
+            | selectattr('__mssql_is_active', 'defined')
+            | selectattr('__mssql_is_active')
+            | map(attribute='inventory_hostname')
+            | list }}
+        failed_hosts: "{{ ansible_play_hosts_all | difference(active_hosts) }}"
+      fail:
+        msg: "These hosts are no longer active: {{ failed_hosts | join(', ') }}"
+      when: failed_hosts | length > 0
+
+    - name: Unset __mssql_is_active
+      set_fact:
+        __mssql_is_active: null
 
     - name: Open required firewall ports and set required facts
       block:
@@ -1277,11 +1322,11 @@
 
         - name: Verify that primary instance hosts is available
           assert:
-            that: ansible_play_hosts |
-                map('extract', hostvars, '__mssql_ha_is_primary') |
-                select('match', '^[Tt]rue$') |
-                list |
-                length == 1
+            that: ansible_play_hosts
+              | map('extract', hostvars, '__mssql_ha_is_primary')
+              | select
+              | list
+              | length == 1
             fail_msg:
               - The role was not able to identify primary replica.
           run_once: true
@@ -1317,6 +1362,25 @@
               - replicate_db.j2
           include_tasks: input_sql_files.yml
 
+    - name: Mark active hosts
+      set_fact:
+        __mssql_is_active: true
+
+    - name: Fail if any hosts are no longer active
+      run_once: true
+      vars:
+        hostvars_list: "{{ ansible_play_hosts_all | map('extract', hostvars) | list }}"
+        active_hosts: >-
+          {{ hostvars_list
+            | selectattr('__mssql_is_active', 'defined')
+            | selectattr('__mssql_is_active')
+            | map(attribute='inventory_hostname')
+            | list }}
+        failed_hosts: "{{ ansible_play_hosts_all | difference(active_hosts) }}"
+      fail:
+        msg: "These hosts are no longer active: {{ failed_hosts | join(', ') }}"
+      when: failed_hosts | length > 0
+
     # In the case of fail over when primary is moved grant permission task above
     # is not run on primary above hence we need to run it separately
     - name: Grant permissions to HA login
@@ -1332,19 +1396,6 @@
     - name: Configure availability group on not primary replicas
       when: mssql_ha_replica_type in __mssql_ha_replica_types_secondary
       block:
-        - name: Verify that hosts with replica_type=primary is available
-          assert:
-            that: ansible_play_hosts |
-                map('extract', hostvars, 'mssql_ha_replica_type') |
-                select('match', '^primary$') |
-                list |
-                length == 1
-            fail_msg:
-              - Host with mssql_ha_replica_type=primary failed earlier
-              - Therefore, it is not possible to configure for high availability
-              - Fix the above error on the primary replica and re-run the role
-          run_once: true
-
         - name: Ensure the package {{ __mssql_server_ha_packages }}
           package:
             name: "{{ __mssql_server_ha_packages }}"

--- a/templates/configure_ag.j2
+++ b/templates/configure_ag.j2
@@ -1,14 +1,38 @@
 IF EXISTS (
   SELECT name, cluster_type_desc
   FROM sys.availability_groups
-  WHERE name = '{{ mssql_ha_ag_name }}' AND
-        cluster_type_desc != '{{ mssql_ha_ag_cluster_type }}'
+  WHERE name = '{{ mssql_ha_ag_name }}'
 )
 BEGIN
-  PRINT 'The existing {{ mssql_ha_ag_name }} availability group has \
+  PRINT 'Verify existing availability group {{ mssql_ha_ag_name }}'
+  IF EXISTS (
+    SELECT name, cluster_type_desc
+    FROM sys.availability_groups
+    WHERE name = '{{ mssql_ha_ag_name }}'
+          AND cluster_type_desc != '{{ mssql_ha_ag_cluster_type }}'
+  )
+  BEGIN
+    PRINT 'The existing {{ mssql_ha_ag_name }} availability group has \
 incorrect cluster type set, dropping the group to re-create it';
-  DROP AVAILABILITY GROUP {{ mssql_ha_ag_name }};
-  PRINT 'The {{ mssql_ha_ag_name }} availability group dropped successfully';
+    DROP AVAILABILITY GROUP {{ mssql_ha_ag_name }};
+    PRINT 'The {{ mssql_ha_ag_name }} availability group dropped successfully';
+  END
+
+{# is_contained was added in SQL Server 2019 #}
+{% if mssql_version is version('2019', '>=') %}
+  IF EXISTS (
+    SELECT name, is_contained
+    FROM sys.availability_groups
+    WHERE name = '{{ mssql_ha_ag_name }}'
+          AND is_contained != {{ 1 if mssql_ha_ag_is_contained else 0 }}
+  )
+  BEGIN
+    PRINT 'The existing {{ mssql_ha_ag_name }} availability group has \
+incorrect is_contained setting, dropping the group to re-create it';
+    DROP AVAILABILITY GROUP {{ mssql_ha_ag_name }};
+    PRINT 'The {{ mssql_ha_ag_name }} availability group dropped successfully';
+  END
+{% endif %}
 END
 
 IF EXISTS (
@@ -18,6 +42,7 @@ IF EXISTS (
 )
 BEGIN
   PRINT 'Verifying the existing availability group {{ mssql_ha_ag_name }}'
+  PRINT 'Verifying {{ mssql_ha_ag_name }} DB_FAILOVER status'
   IF NOT EXISTS (
     SELECT name, db_failover
     FROM sys.availability_groups
@@ -27,14 +52,15 @@ BEGIN
   BEGIN
     ALTER AVAILABILITY GROUP {{ mssql_ha_ag_name }}
       SET (DB_FAILOVER = {{ __mssql_ha_db_failover }})
-    PRINT 'Set DB_FAILOVER to ON succesfully'
+    PRINT 'Set DB_FAILOVER to ON successfully'
   END
   ELSE
   BEGIN
     PRINT 'DB_FAILOVER = ON is already set, skipping'
   END
+
   PRINT 'Verifying replicas'
-{# Sort ansible_play_hosts #}
+{# Sort ansible_play_hosts_all #}
 {# Sort primary replica as the last in the list #}
 {# Sort witness replica as the next-to-last in the list #}
 {# Configure primary last because it has information about other replicas #}
@@ -43,7 +69,7 @@ BEGIN
 {# replica which has configuration-only availability mode.' #}
 {% set ag_replicas_primary_last = [] %}
 {# In the first loop, add primaries at the end and witness at the beginning #}
-{% for item in ansible_play_hosts %}
+{% for item in ansible_play_hosts_all %}
 {%   if hostvars[item]['mssql_ha_replica_type'] == 'primary' %}
 {{ ag_replicas_primary_last.append(item) -}}
 {%   elif hostvars[item]['mssql_ha_replica_type'] == 'witness' %}
@@ -51,7 +77,7 @@ BEGIN
 {%   endif %}
 {% endfor %}
 {# In the second loop, add others at the beginning #}
-{% for item in ansible_play_hosts %}
+{% for item in ansible_play_hosts_all %}
 {%   if hostvars[item]['mssql_ha_replica_type']
      not in ag_replicas_primary_last %}
 {{ ag_replicas_primary_last.insert(0, item) -}}
@@ -209,31 +235,62 @@ successfully';
 {% endfor %}
 END
 
+{# is_contained was added in SQL Server 2019 #}
+{% if (not mssql_ha_ag_is_contained) or (mssql_version is version('2019', '<')) %}
+{%   set __contained_reuse_system_db = "" %}
+{% elif mssql_ha_ag_is_contained %}
+{%   set __contained_reuse_system_db = ",CONTAINED" %}
+{%   if mssql_ha_ag_reuse_system_db %}
+{%     set __contained_reuse_system_db = __contained_reuse_system_db + ",REUSE_SYSTEM_DATABASES" %}
+{%   endif %}
+{% endif %}
+
 IF NOT EXISTS (
   SELECT name, cluster_type_desc
   FROM sys.availability_groups
   WHERE name = '{{ mssql_ha_ag_name }}'
 )
 BEGIN
+{% if mssql_ha_ag_reuse_system_db %}
+{%   set sys_dbs = [mssql_ha_ag_name ~ '_master', mssql_ha_ag_name ~ '_msdb'] %}
+{%   for sys_db in sys_dbs %}
+  IF EXISTS (
+    SELECT name, state_desc
+    FROM sys.databases
+    WHERE state_desc = 'RESTORING'
+      AND name='{{ sys_db }}'
+  )
+  BEGIN
+    PRINT 'The system database {{ sys_db }} is in restoring state, running \
+restore to reuse it for the newly created AG {{ mssql_ha_ag_name }}';
+    RESTORE DATABASE [{{ sys_db }}];
+    PRINT 'The {{ sys_db }} database restored successfully';
+  END
+  ELSE
+  BEGIN
+    PRINT 'The {{ sys_db }} database is already online, skipping';
+  END
+{%   endfor %}
+{% endif %}
   PRINT 'Creating the {{ mssql_ha_ag_name }} availability group';
   CREATE AVAILABILITY GROUP {{ mssql_ha_ag_name }}
     WITH (
       DB_FAILOVER = {{ __mssql_ha_db_failover }},
-      CLUSTER_TYPE = {{ mssql_ha_ag_cluster_type }}
+      CLUSTER_TYPE = {{ mssql_ha_ag_cluster_type }}{{ __contained_reuse_system_db }}
     )
     FOR REPLICA ON
-{# Sort ansible_play_hosts #}
+{# Sort ansible_play_hosts_all #}
 {# Sort primary replica as the first in the list #}
 {# Configure AG with primary replica first because SQL Server requires this #}
 {% set ag_replicas_primary_first = [] %}
 {# In the first loop, add not primaries to a new list #}
-{% for item in ansible_play_hosts %}
+{% for item in ansible_play_hosts_all %}
 {%   if hostvars[item]['mssql_ha_replica_type'] != 'primary' %}
 {{ ag_replicas_primary_first.append(item) -}}
 {%   endif %}
 {% endfor %}
 {# In the second loop, add primary at the beginning #}
-{% for item in ansible_play_hosts %}
+{% for item in ansible_play_hosts_all %}
 {%   if hostvars[item]['mssql_ha_replica_type'] == 'primary' %}
 {{ ag_replicas_primary_first.insert(0, item) -}}
 {%   endif %}

--- a/templates/replicate_db.j2
+++ b/templates/replicate_db.j2
@@ -17,6 +17,23 @@ BEGIN
   PRINT 'RECOVERY FULL on the {{ item }} database is set, skipping';
 END
 
+IF EXISTS (
+  SELECT name, state_desc
+  FROM sys.databases
+  WHERE state_desc = 'RESTORING'
+    AND name='{{ item }}'
+)
+BEGIN
+  PRINT 'The {{ item }} database is in restoring state, running restore with \
+recovery to add it to AG after';
+  RESTORE DATABASE [{{ item }}] WITH RECOVERY;
+  PRINT 'The {{ item }} database restored with recovery successfully';
+END
+ELSE
+BEGIN
+  PRINT 'The {{ item }} database is already online, skipping';
+END
+
 IF NOT EXISTS (
   SELECT [database_name], backup_start_date, backup_finish_date, [type]
   FROM msdb.dbo.backupset

--- a/tests/tasks/assert_fail_on_unsupported_ver.yml
+++ b/tests/tasks/assert_fail_on_unsupported_ver.yml
@@ -3,16 +3,15 @@
   setup:
     gather_subset: min
 
-- name: Assert fail on EL 7 with version = 2022 and EL 9 with version != 2022
+- name: Assert fail when used on platform where mssql_version is not supported
   when: >-
-    (ansible_distribution in ['CentOS', 'RedHat'] and
-    ansible_distribution_major_version is version('7', '=') and
-    mssql_version | int == 2022) or
-    (((ansible_distribution in ['CentOS', 'RedHat'] and
-    ansible_distribution_major_version is version('9', '=')) or
-    (ansible_distribution in ['Fedora']))
-    and
-    mssql_version | int != 2022)
+    (ansible_distribution in ['CentOS', 'RedHat']
+    and ansible_distribution_major_version is version('7', '=')
+    and mssql_version | int == 2022)
+    or (((ansible_distribution in ['CentOS', 'RedHat']
+    and ansible_distribution_major_version is version('9', '='))
+    or (ansible_distribution in ['Fedora']))
+    and mssql_version | int != 2022)
   block:
     - name: Run the role
       vars:
@@ -25,7 +24,7 @@
       fail:
         msg: The above task must fail
   rescue:
-    - name: Assert that the role failed with EL < 8 not supported
+    - name: Assert that the role failed with mssql_version not supported
       assert:
         that: >-
           'You must set the mssql_version variable to one of'

--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 ---
 - name: Gather package facts
   package_facts:
@@ -67,7 +68,7 @@
     /opt/mssql*
     /var/log/pacemaker/pacemaker.log
     /etc/yum.repos.d/packages-microsoft-com-*
-    /tmp/*.j2
+    /tmp/*.j2_*
     /tmp/mssql_data
     /tmp/mssql_log
     /etc/systemd/system/mssql-server.service.d

--- a/tests/tasks/cleanup_ag.yml
+++ b/tests/tasks/cleanup_ag.yml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Remove AG to re-create it with reuse_system_db on secondary
+  when: not __mssql_ha_is_primary
+  vars:
+    __mssql_sql_files_to_input:
+      - drop_ag.j2
+  include_role:
+    name: linux-system-roles.mssql
+    tasks_from: input_sql_files.yml
+    public: true
+
+- name: Drop DBs on secondaries
+  when: not __mssql_ha_is_primary
+  vars:
+    __mssql_sql_files_to_input:
+      - drop_dbs.j2
+    __mssql_rm_dbs: "{{ mssql_ha_db_names }}"
+  include_role:
+    name: linux-system-roles.mssql
+    tasks_from: input_sql_files.yml
+    public: true

--- a/tests/tasks/tests_ha_single.yml
+++ b/tests/tasks/tests_ha_single.yml
@@ -1,0 +1,865 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Verify that the role fails when primary node is not specified
+  when: ansible_play_hosts_all | length == 1
+  block:
+    - name: Run role with mssql_replica_type=primary not defined
+      include_role:
+        name: linux-system-roles.mssql
+
+    - name: Unreachable task
+      fail:
+        msg: The above task must fail
+  rescue:
+    - name: Assert that the role fails when primary node is not specified
+      assert:
+        that: >-
+          'You must set the mssql_ha_replica_type variable to one of
+          primary, synchronous, asynchronous, witness, absent'
+          in ansible_failed_result.msg
+
+- name: Set the mssql_ha_replica_type fact to appear in hostvars
+  set_fact:
+    mssql_ha_replica_type: primary
+
+- name: Assert fail on EL 7 with version = 2022 and EL 9 with version != 2022
+  include_tasks: assert_fail_on_unsupported_ver.yml
+
+- name: Verify that by default the role fails on EL < 8
+  when:
+    - ansible_distribution in ['CentOS', 'RedHat']
+    - ansible_distribution_version is version('8', '<')
+  block:
+    - name: Run the role
+      vars:
+        mssql_ha_configure: true
+      include_role:
+        name: linux-system-roles.mssql
+
+    - name: Unreachable task
+      fail:
+        msg: The above task must fail
+  rescue:
+    - name: Assert that the role failed with EL 7 not supported
+      assert:
+        that: >-
+          'mssql_ha_configure=true does not support running against EL 7
+          hosts' in ansible_failed_result.msg
+  always:
+    - name: Clean up after the role invocation
+      include_tasks: tasks/cleanup.yml
+      when: ansible_play_hosts_all | length == 1
+
+    # Putting end_host into a rescue block results in a failed task
+    - name: End EL 7 host
+      meta: end_host
+
+- name: Verify fail when ag_is_contained=false,reuse_system_db=true
+  block:
+    - name: Run role with mssql_ha_ag_is_contained=false reuse_db=true
+      vars:
+        mssql_ha_ag_is_contained: false
+        mssql_ha_ag_reuse_system_db: true
+      include_role:
+        name: linux-system-roles.mssql
+
+    - name: Unreachable task
+      fail:
+        msg: The above task must fail
+  rescue:
+    - name: Assert that the role failed with reuse_db not supported
+      assert:
+        that: >-
+          'mssql_ha_ag_reuse_system_db is not appilcable when
+          mssql_ha_ag_is_contained = false'
+          in ansible_failed_result.msg
+
+- name: Verify fail when running on <2022 with ag_is_contained = true
+  when: mssql_version is version('2022', '<')
+  block:
+    - name: Run role with mssql_ha_ag_is_contained = true
+      vars:
+        mssql_ha_ag_is_contained: true
+      include_role:
+        name: linux-system-roles.mssql
+
+    - name: Unreachable task
+      fail:
+        msg: The above task must fail
+  rescue:
+    - name: Assert that the role failed with contained not supported
+      assert:
+        that: >-
+          'mssql_ha_ag_is_contained is not supported on SQL Server <
+          2022'
+          in ansible_failed_result.msg
+
+- name: Set the mssql_ha_replica_type fact to appear in hostvars
+  set_fact:
+    mssql_ha_replica_type: primary
+  when:
+    - ansible_play_hosts_all | length == 1
+    - mssql_ha_replica_type is not defined
+
+- name: Load softdog module for stonith to have at least one watchdog
+  command: modprobe softdog
+  changed_when: true
+
+- name: Set facts to create test DBs on primary as a pre task
+  set_fact:
+    mssql_pre_input_sql_file:
+      - create_ExampleDB1.sql
+      - create_ExampleDB2.sql
+  when: mssql_ha_replica_type == 'primary'
+
+- name: Set up test environment for the ha_cluster role
+  include_role:
+    name: fedora.linux_system_roles.ha_cluster
+    tasks_from: test_setup.yml
+
+# ha_cluster/tasks/test_setup.yml has a task "Set node name to 'localhost'"
+# that sets inventory_hostname to localhost. mssql needs a proper
+# inventory_hostname to identify failed nodes, hence resetting it here
+- name: Reset inventory_hostname fact
+  set_fact:
+    inventory_hostname: "{{ ansible_play_hosts[0] }}"  # noqa: var-naming
+
+- name: Run on all hosts to configure HA cluster
+  include_role:
+    name: linux-system-roles.mssql
+
+# The following tasks test if templates configure systems correctly
+# Because CI runs on a single node, these templates can't be tested:
+# * remove_from_ag.j2
+# * join_to_ag.j2
+# * removing and adding replicas in configure_ag.j2
+- name: >-
+    Don't test templates when testing against multiple hosts.
+    Testing templates only supported for primary replicas
+  meta: end_play
+  when: >-
+    (ansible_play_hosts_all | length > 1)
+    or
+    (mssql_ha_replica_type | d('primary') != 'primary')
+
+- name: Set the mssql_ha_replica_type fact to appear in hostvars
+  set_fact:
+    mssql_ha_replica_type: primary
+  when:
+    - ansible_play_hosts_all | length == 1
+    - mssql_ha_replica_type is not defined
+
+# enable_alwayson.j2 template test
+- name: Enable AlwaysOn event session when it's enabled
+  vars:
+    # noqa var-naming[no-role-prefix]
+    __mssql_sql_files_to_input:
+      - enable_alwayson.j2
+  include_role:
+    name: linux-system-roles.mssql
+    tasks_from: input_sql_files.yml
+    public: true
+
+- name: Assert that enabling is skipped
+  assert:
+    that: >-
+      "AlwaysOn Health events already enabled, skipping"
+      in __mssql_sqlcmd_input.stdout
+
+- name: Disable AlwaysOn event session
+  vars:
+    # noqa var-naming[no-role-prefix]
+    __mssql_sql_files_to_input:
+      - disable_alwayson.j2
+  include_role:
+    name: linux-system-roles.mssql
+    tasks_from: input_sql_files.yml
+
+- name: Enable AlwaysOn event session
+  vars:
+    # noqa var-naming[no-role-prefix]
+    __mssql_sql_files_to_input:
+      - enable_alwayson.j2
+  include_role:
+    name: linux-system-roles.mssql
+    tasks_from: input_sql_files.yml
+
+- name: Assert that the template reported changed state
+  assert:
+    that: >-
+      "AlwaysOn Health events enabled successfully"
+      in __mssql_sqlcmd_input.stdout
+
+# configure_endpoint.j2 template test
+- name: Create endpoint when it exists
+  vars:
+    # noqa var-naming[no-role-prefix]
+    __mssql_sql_files_to_input:
+      - configure_endpoint.j2
+  include_role:
+    name: linux-system-roles.mssql
+    tasks_from: input_sql_files.yml
+
+- name: Assert expected messages
+  assert:
+    that:
+      - >-
+        "Verifying the existing endpoint {{ mssql_ha_endpoint_name }}"
+        in __mssql_sqlcmd_input.stdout
+      - >-
+        "The LISTENER_PORT setting for the {{ mssql_ha_endpoint_name }}
+        endpoint is already set to {{ mssql_ha_endpoint_port }},
+        skipping"
+        in __mssql_sqlcmd_input.stdout
+      - >-
+        "The ROLE setting for the {{ mssql_ha_endpoint_name }} endpoint
+        is already set to {{ __mssql_ha_endpoint_role }}, skipping"
+        in __mssql_sqlcmd_input.stdout
+      - >-
+        "The certificate for the {{ mssql_ha_endpoint_name }}
+        endpoint is already set to {{ mssql_ha_cert_name }}, skipping"
+        in __mssql_sqlcmd_input.stdout
+      - >-
+        "The ENCRYPTION setting for the {{ mssql_ha_endpoint_name }}
+        endpoint is already set to AES, skipping"
+        in __mssql_sqlcmd_input.stdout
+      - >-
+        "Endpoint {{ mssql_ha_endpoint_name }} is already started,
+        skipping"
+        in __mssql_sqlcmd_input.stdout
+
+- name: Alter endpoint to test how template handles incorrect endpoint
+  vars:
+    # noqa var-naming[no-role-prefix]
+    __mssql_sql_files_to_input:
+      - alter_endpoint.j2
+  include_role:
+    name: linux-system-roles.mssql
+    tasks_from: input_sql_files.yml
+
+- name: Configure endpoint correctly
+  vars:
+    # noqa var-naming[no-role-prefix]
+    __mssql_sql_files_to_input:
+      - configure_endpoint.j2
+  include_role:
+    name: linux-system-roles.mssql
+    tasks_from: input_sql_files.yml
+
+- name: Assert expected messages
+  assert:
+    that:
+      - >-
+        "Verifying the existing endpoint {{ mssql_ha_endpoint_name }}"
+        in __mssql_sqlcmd_input.stdout
+      - >-
+        "The LISTENER_PORT setting for the {{ mssql_ha_endpoint_name }}
+        endpoint updated to {{ mssql_ha_endpoint_port }} successfully"
+        in __mssql_sqlcmd_input.stdout
+      - >-
+        "The ROLE setting for the {{ mssql_ha_endpoint_name }}
+        endpoint updated to {{ __mssql_ha_endpoint_role }} successfully"
+        in __mssql_sqlcmd_input.stdout
+      - >-
+        "The certificate for the {{ mssql_ha_endpoint_name }}
+        endpoint updated to {{ mssql_ha_cert_name }} successfully"
+        in __mssql_sqlcmd_input.stdout
+      - >-
+        "The ENCRYPTION setting for the {{ mssql_ha_endpoint_name }}
+        endpoint updated to AES successfully"
+        in __mssql_sqlcmd_input.stdout
+      - >-
+        "Endpoint {{ mssql_ha_endpoint_name }} started successfully"
+        in __mssql_sqlcmd_input.stdout
+
+- name: Drop the test_cert certificate
+  vars:
+    # noqa var-naming[no-role-prefix]
+    __mssql_sql_files_to_input:
+      - drop_cert.j2
+    mssql_ha_cert_name: test_cert
+  include_role:
+    name: linux-system-roles.mssql
+    tasks_from: input_sql_files.yml
+
+# # configure_listener.j2 template test
+# - name: Remove a listener for test purposes
+#   vars:
+#     # noqa var-naming[no-role-prefix]
+#     __mssql_sql_files_to_input:
+#       - remove_listener.j2
+#   include_role:
+#     name: linux-system-roles.mssql
+#     tasks_from: input_sql_files.yml
+
+# - name: Add a listener with a different name
+#   vars:
+#     # noqa var-naming[no-role-prefix]
+#     __mssql_sql_files_to_input:
+#       - add_test_listener.j2
+#   include_role:
+#     name: linux-system-roles.mssql
+#     tasks_from: input_sql_files.yml
+
+# - name: Modify a listener
+#   vars:
+#     # noqa var-naming[no-role-prefix]
+#     __mssql_sql_files_to_input:
+#       - configure_listener.j2
+#     mssql_tcp_port: 1435
+#     mssql_ha_virtual_ip: 192.168.122.149
+#   include_role:
+#     name: linux-system-roles.mssql
+#     tasks_from: input_sql_files.yml
+
+# - name: Assert expected messages
+#   assert:
+#     that:
+#       - >-
+#         "Verifying the existing listener TEST-listener"
+#         in __mssql_sqlcmd_input.stdout
+#       - >-
+#         "Modifying the listener port setting"
+#         in __mssql_sqlcmd_input.stdout
+#       - >-
+#         "Set listener port to 1435 successfully"
+#         in __mssql_sqlcmd_input.stdout
+#       - >-
+#         "Modifying the listener ip address setting"
+#         in __mssql_sqlcmd_input.stdout
+#       - >-
+#         "Added listener ip address 192.168.122.149,255.255.255.0
+#         successfully"
+#         in __mssql_sqlcmd_input.stdout
+
+# - name: Remove a listener to re-create with default values
+#   vars:
+#     # noqa var-naming[no-role-prefix]
+#     __mssql_sql_files_to_input:
+#       - remove_listener.j2
+#     mssql_listener_name: TEST
+#   include_role:
+#     name: linux-system-roles.mssql
+#     tasks_from: input_sql_files.yml
+
+# - name: Add a listener with previous settings
+#   vars:
+#     # noqa var-naming[no-role-prefix]
+#     __mssql_sql_files_to_input:
+#       - configure_listener.j2
+#   include_role:
+#     name: linux-system-roles.mssql
+#     tasks_from: input_sql_files.yml
+
+# - name: Assert expected messages
+#   assert:
+#     that:
+#       - >-
+#         "Adding the {{ mssql_ha_ag_name }}-listener listener to the
+#         {{ mssql_ha_ag_name }} availability group"
+#         in __mssql_sqlcmd_input.stdout
+#       - >-
+#         "Added the {{ mssql_ha_ag_name }}-listener listener
+#         successfully"
+#         in __mssql_sqlcmd_input.stdout
+
+- name: Add a listener when it exists
+  vars:
+    # noqa var-naming[no-role-prefix]
+    __mssql_sql_files_to_input:
+      - configure_listener.j2
+  include_role:
+    name: linux-system-roles.mssql
+    tasks_from: input_sql_files.yml
+
+- name: Assert expected messages
+  assert:
+    that:
+      - >-
+        "Verifying the existing listener
+        {{ mssql_ha_ag_name }}-listener"
+        in __mssql_sqlcmd_input.stdout
+      - >-
+        "The port setting is already set correctly, skipping"
+        in __mssql_sqlcmd_input.stdout
+      - >-
+        "The listener ip address setting is already set correctly,
+        skipping"
+        in __mssql_sqlcmd_input.stdout
+
+# create_master_key_encryption.j2 template test
+- name: Create a master key when it exists
+  vars:
+    # noqa var-naming[no-role-prefix]
+    __mssql_sql_files_to_input:
+      - create_master_key_encryption.j2
+  include_role:
+    name: linux-system-roles.mssql
+    tasks_from: input_sql_files.yml
+
+- name: Assert that creating is skipped
+  assert:
+    that: >-
+      "The provided master key password is correct"
+      in __mssql_sqlcmd_input.stdout
+
+- name: Verify creating master key with incorrect password
+  block:
+    - name: Try creating master key with incorrect password
+      vars:
+        # noqa var-naming[no-role-prefix]
+        __mssql_sql_files_to_input:
+          - create_master_key_encryption.j2
+        mssql_ha_master_key_password: "p@55w0rD11"
+      include_role:
+        name: linux-system-roles.mssql
+        tasks_from: input_sql_files.yml
+
+    - name: This task shouldn't execute
+      fail:
+  rescue:
+    - name: Assert the incorrect password error message
+      assert:
+        that: >-
+          "You provided an incorrect master key password"
+          in __mssql_sqlcmd_input.stdout
+
+- name: Drop endpoint
+  vars:
+    # noqa var-naming[no-role-prefix]
+    __mssql_sql_files_to_input:
+      - create_master_key_encryption.j2
+  include_role:
+    name: linux-system-roles.mssql
+    tasks_from: input_sql_files.yml
+
+- name: Remove certs from SQL Server to verify re-creating master key
+  vars:
+    # noqa var-naming[no-role-prefix]
+    __mssql_sql_files_to_input:
+      - drop_cert.j2
+  include_role:
+    name: linux-system-roles.mssql
+    tasks_from: input_sql_files.yml
+
+- name: Remove certificate and private key
+  file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ __mssql_ha_cert_dest }}"
+    - "{{ __mssql_ha_private_key_dest }}"
+
+- name: >-
+    Verify creating master key with incorrect password and
+    mssql_ha_reset_cert set to true
+  vars:
+    # noqa var-naming[no-role-prefix]
+    __mssql_sql_files_to_input:
+      - create_master_key_encryption.j2
+    mssql_ha_master_key_password: "p@55w0rD11"
+    mssql_ha_reset_cert: true
+  include_role:
+    name: linux-system-roles.mssql
+    tasks_from: input_sql_files.yml
+
+- name: Assert the expected error message
+  assert:
+    that:
+      - >-
+        "dropping master key to re-create it"
+        in __mssql_sqlcmd_input.stdout
+      - >-
+        "Master key dropped successfully"
+        in __mssql_sqlcmd_input.stdout
+      - >-
+        "Master key created successfully"
+        in __mssql_sqlcmd_input.stdout
+
+# # restore_cert.j2 template test
+# - name: Create a certificate when it exists on secondary
+#   when: mssql_ha_replica_type in ['synchronous', 'witness']
+#   block:
+#     - name: Input restore_cert.j2
+#       vars:
+#         __mssql_sql_files_to_input:
+#           - restore_cert.j2
+#       include_role:
+#         name: linux-system-roles.mssql
+#         tasks_from: input_sql_files.yml
+
+#     - name: Assert the already exists message
+#       assert:
+#         that: >-
+#           "Certificate {{ mssql_ha_cert_name }} already exists,
+#           skipping"
+#           in __mssql_sqlcmd_input.stdout
+
+# create_and_back_up_cert.j2 template test
+- name: Create and back up an existing and backed up certificate
+  when: mssql_ha_replica_type == 'primary'
+  block:
+    - name: Input create_and_back_up_cert.j2 to create cert
+      vars:
+        # noqa var-naming[no-role-prefix]
+        __mssql_sql_files_to_input:
+          - create_and_back_up_cert.j2
+      include_role:
+        name: linux-system-roles.mssql
+        tasks_from: input_sql_files.yml
+
+    - name: Assert created successfully messages
+      assert:
+        that:
+          - >-
+            "Certificate {{ mssql_ha_cert_name }} created successfully"
+            in __mssql_sqlcmd_input.stdout
+          - >-
+            "{{ __mssql_ha_cert_dest }} and
+            {{ __mssql_ha_private_key_dest }} exported successfully"
+            in __mssql_sqlcmd_input.stdout
+
+    - name: Input create_and_back_up_cert.j2 when cert exists
+      vars:
+        # noqa var-naming[no-role-prefix]
+        __mssql_sql_files_to_input:
+          - create_and_back_up_cert.j2
+      include_role:
+        name: linux-system-roles.mssql
+        tasks_from: input_sql_files.yml
+
+    - name: Assert task skipping messages
+      assert:
+        that:
+          - >-
+            "Certificate {{ mssql_ha_cert_name }} already exists,
+            skipping"
+            in __mssql_sqlcmd_input.stdout
+          - >-
+            "{{ __mssql_ha_cert_dest }} and
+            {{ __mssql_ha_private_key_dest }} already exist, skipping"
+            in __mssql_sqlcmd_input.stdout
+
+    - name: Back up certificate and private key
+      copy:
+        remote_src: true
+        src: "{{ item }}"
+        dest: /tmp/{{ item | basename }}
+        mode: "0600"
+      loop:
+        - "{{ __mssql_ha_cert_dest }}"
+        - "{{ __mssql_ha_private_key_dest }}"
+
+    - name: Remove private key
+      file:
+        path: "{{ __mssql_ha_private_key_dest }}"
+        state: absent
+
+    - name: Input create_and_back_up_cert.j2
+      vars:
+        # noqa var-naming[no-role-prefix]
+        __mssql_sql_files_to_input:
+          - create_and_back_up_cert.j2
+      include_role:
+        name: linux-system-roles.mssql
+        tasks_from: input_sql_files.yml
+
+    - name: Assert expected error messages
+      assert:
+        that:
+          - >-
+            "Certificate {{ mssql_ha_cert_name }} already exists,
+            skipping"
+            in __mssql_sqlcmd_input.stdout
+          - >-
+            "{{ __mssql_ha_private_key_dest }} does not exist while
+            {{ __mssql_ha_cert_dest }} exists."
+            in __mssql_sqlcmd_input.stdout
+
+    - name: Remove certificate
+      file:
+        path: "{{ __mssql_ha_cert_dest }}"
+        state: absent
+
+    - name: Return private key
+      copy:
+        remote_src: true
+        src: /tmp/{{ __mssql_ha_private_key_dest | basename }}
+        dest: "{{ __mssql_ha_private_key_dest }}"
+        mode: "0600"
+
+    - name: Input create_and_back_up_cert.j2
+      vars:
+        # noqa var-naming[no-role-prefix]
+        __mssql_sql_files_to_input:
+          - create_and_back_up_cert.j2
+      include_role:
+        name: linux-system-roles.mssql
+        tasks_from: input_sql_files.yml
+
+    - name: Assert expected error messages
+      assert:
+        that:
+          - >-
+            "Certificate {{ mssql_ha_cert_name }} already exists,
+            skipping"
+            in __mssql_sqlcmd_input.stdout
+          - >-
+            "{{ __mssql_ha_cert_dest }} does not exist while
+            {{ __mssql_ha_private_key_dest }} exists."
+            in __mssql_sqlcmd_input.stdout
+
+    - name: Return certificate
+      copy:
+        remote_src: true
+        src: /tmp/{{ __mssql_ha_cert_dest | basename }}
+        dest: "{{ __mssql_ha_cert_dest }}"
+        mode: "0600"
+
+    - name: Drop certificate from SQL Server
+      vars:
+        # noqa var-naming[no-role-prefix]
+        __mssql_sql_files_to_input:
+          - drop_cert.j2
+      include_role:
+        name: linux-system-roles.mssql
+        tasks_from: input_sql_files.yml
+
+    - name: Create cert when cert files exist and SQL cert does not
+      block:
+        - name: Input create_and_back_up_cert.j2
+          vars:
+            # noqa var-naming[no-role-prefix]
+            __mssql_sql_files_to_input:
+              - create_and_back_up_cert.j2
+          include_role:
+            name: linux-system-roles.mssql
+            tasks_from: input_sql_files.yml
+
+        - name: Unreachable task
+          fail:
+            msg: The above task must fail
+      rescue:
+        - name: Assert expected error messages
+          assert:
+            that:
+              - >-
+                "Certificate {{ mssql_ha_cert_name }} does not exist in
+                SQL Server, however, {{ __mssql_ha_cert_dest }} and/or
+                {{ __mssql_ha_private_key_dest }} files do exist."
+                in __mssql_sqlcmd_input.stdout
+
+    - name: Remove certificate and private key
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ __mssql_ha_cert_dest }}"
+        - "{{ __mssql_ha_private_key_dest }}"
+
+    - name: Ensure that certificates exist
+      vars:
+        # noqa var-naming[no-role-prefix]
+        __mssql_sql_files_to_input:
+          - create_and_back_up_cert.j2
+      include_role:
+        name: linux-system-roles.mssql
+        tasks_from: input_sql_files.yml
+
+    - name: Assert expected messages
+      assert:
+        that: >-
+          "Certificate {{ mssql_ha_cert_name }} created successfully"
+          in __mssql_sqlcmd_input.stdout
+
+# create_ha_login.j2 template test
+- name: Create a login when it already exists {{ mssql_ha_login }}
+  vars:
+    # noqa var-naming[no-role-prefix]
+    __mssql_sql_files_to_input:
+      - create_ha_login.j2
+  include_role:
+    name: linux-system-roles.mssql
+    tasks_from: input_sql_files.yml
+
+- name: Assert task skipping messages
+  assert:
+    that:
+      - >-
+        "A {{ mssql_ha_login }} login already exists, skipping"
+        in __mssql_sqlcmd_input.stdout
+      - >-
+        "{{ mssql_ha_login }} is a member of sysadmin role, skipping"
+        in __mssql_sqlcmd_input.stdout
+
+# replicate_db.j2 template test
+- name: Replicate database what it is already replicated
+  when: mssql_ha_replica_type == 'primary'
+  block:
+    - name: Input replicate_db.j2
+      vars:
+        # noqa var-naming[no-role-prefix]
+        __mssql_sql_files_to_input:
+          - replicate_db.j2
+      include_role:
+        name: linux-system-roles.mssql
+        tasks_from: input_sql_files.yml
+
+    - name: Assert task skipping messages
+      assert:
+        that:
+          - >-
+            "RECOVERY FULL on the ExampleDB1 database is set, skipping"
+            in __mssql_sqlcmd_input.stdout
+          - >-
+            "The ExampleDB1 database is already backed up, skipping"
+            in __mssql_sqlcmd_input.stdout
+          - >-
+            "The ExampleDB1 database is already added to the ExampleAG
+            availability group, skipping"
+            in __mssql_sqlcmd_input.stdout
+          - >-
+            "RECOVERY FULL on the ExampleDB2 database is set, skipping"
+            in __mssql_sqlcmd_input.stdout
+          - >-
+            "The ExampleDB2 database is already backed up, skipping"
+            in __mssql_sqlcmd_input.stdout
+          - >-
+            "The ExampleDB2 database is already added to the ExampleAG
+            availability group, skipping"
+            in __mssql_sqlcmd_input.stdout
+
+# configure_ag.yml template test
+- name: Ensure endpoint exists
+  vars:
+    # noqa var-naming[no-role-prefix]
+    __mssql_sql_files_to_input:
+      - configure_endpoint.j2
+  include_role:
+    name: linux-system-roles.mssql
+    tasks_from: input_sql_files.yml
+
+- name: Test configure_ag.yml on primary
+  when: mssql_ha_replica_type == 'primary'
+  block:
+    - name: Input configure_ag.yml when AG exists
+      vars:
+        # noqa var-naming[no-role-prefix]
+        __mssql_sql_files_to_input:
+          - configure_ag.j2
+      include_role:
+        name: linux-system-roles.mssql
+        tasks_from: input_sql_files.yml
+
+    - name: Assert task skipping messages
+      assert:
+        that:
+          - >-
+            "DB_FAILOVER = ON is already set, skipping"
+            in __mssql_sqlcmd_input.stdout
+          - >-
+            "The ENDPOINT_URL setting on this
+            {{ mssql_ha_replica_type }} replica is already set
+            correctly, skipping"
+            in __mssql_sqlcmd_input.stdout
+          - >-
+            "The FAILOVER_MODE setting on this
+            {{ mssql_ha_replica_type }} replica is already set
+            correctly, skipping"
+            in __mssql_sqlcmd_input.stdout
+          - >-
+            "The SEEDING_MODE setting on this
+            {{ mssql_ha_replica_type }} replica is already set
+            correctly, skipping"
+            in __mssql_sqlcmd_input.stdout
+          - >-
+            "The SECONDARY_ROLE (ALLOW_CONNECTIONS = ALL) setting on
+            this {{ mssql_ha_replica_type }} replica is already set
+            correctly"
+            in __mssql_sqlcmd_input.stdout
+
+    # Using mssql_ha_ag_name: ag2 because running tasks against ag1
+    # fails with "Replica not Primary"
+    - name: Verify configuration of a new ag2
+      vars:
+        # noqa var-naming[no-role-prefix]
+        __mssql_sql_files_to_input:
+          - configure_ag_cluster_type_none.j2
+        mssql_ha_ag_name: ag2
+      block:
+        - name: Configure AG with CLUSTER_TYPE = NONE
+          include_role:
+            name: linux-system-roles.mssql
+            tasks_from: input_sql_files.yml
+
+        - name: Input configure_ag.yml with CLUSTER_TYPE = NONE
+          vars:
+            # noqa var-naming[no-role-prefix]
+            __mssql_sql_files_to_input:
+              - configure_ag.j2
+          include_role:
+            name: linux-system-roles.mssql
+            tasks_from: input_sql_files.yml
+
+        - name: Assert task skipping messages
+          assert:
+            that:
+              - >-
+                "The existing {{ mssql_ha_ag_name }} availability group
+                has incorrect cluster type set, dropping the group to
+                re-create it"
+                in __mssql_sqlcmd_input.stdout
+              - >-
+                "The {{ mssql_ha_ag_name }} availability group dropped
+                successfully"
+                in __mssql_sqlcmd_input.stdout
+              - >-
+                "The {{ mssql_ha_ag_name }} availability group created
+                successfully"
+                in __mssql_sqlcmd_input.stdout
+
+        - name: Alter AG
+          vars:
+            # noqa var-naming[no-role-prefix]
+            __mssql_sql_files_to_input:
+              - alter_ag.j2
+          include_role:
+            name: linux-system-roles.mssql
+            tasks_from: input_sql_files.yml
+
+        - name: Input configure_ag.yml to configure ag properly
+          vars:
+            # noqa var-naming[no-role-prefix]
+            __mssql_sql_files_to_input:
+              - configure_ag.j2
+          include_role:
+            name: linux-system-roles.mssql
+            tasks_from: input_sql_files.yml
+
+        - name: Assert task skipping messages
+          assert:
+            that:
+              - >-
+                "Verifying the existing availability group
+                {{ mssql_ha_ag_name }}"
+                in __mssql_sqlcmd_input.stdout
+              - >-
+                "The ENDPOINT_URL setting on this
+                {{ mssql_ha_replica_type }} replica configured
+                successfully"
+                in __mssql_sqlcmd_input.stdout
+              - >-
+                "The FAILOVER_MODE setting on this
+                {{ mssql_ha_replica_type }} replica is already set
+                correctly, skipping"
+                in __mssql_sqlcmd_input.stdout
+              - >-
+                "The SEEDING_MODE setting on this
+                {{ mssql_ha_replica_type }} replica configured
+                successfully"
+                in __mssql_sqlcmd_input.stdout
+              - >-
+                "The SECONDARY_ROLE (ALLOW_CONNECTIONS = ALL) setting on
+                this {{ mssql_ha_replica_type }} replica configured
+                successfully"
+                in __mssql_sqlcmd_input.stdout

--- a/tests/tasks/verify_contained.yml
+++ b/tests/tasks/verify_contained.yml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Verify that contained AG is configured
+  vars:
+    __mssql_sql_files_to_input:
+      - ag_is_contained.j2
+  include_role:
+    name: linux-system-roles.mssql
+    tasks_from: input_sql_files.yml
+    public: true
+
+- name: Assert the contained status equals {{ __mssql_is_contained }}
+  assert:
+    that: __mssql_is_contained == __mssql_sqlcmd_input.stdout | int

--- a/tests/templates/ag_is_contained.j2
+++ b/tests/templates/ag_is_contained.j2
@@ -1,0 +1,24 @@
+-- Get major version number (e.g., 15 for SQL Server 2019)
+DECLARE @MajorVersion INT
+SET @MajorVersion = CAST(PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS NVARCHAR), 4) AS INT)
+
+IF @MajorVersion >= 15
+BEGIN
+    IF EXISTS (
+        SELECT name, is_contained
+        FROM sys.availability_groups
+        WHERE name = '{{ mssql_ha_ag_name }}'
+              AND is_contained = 1
+    )
+    BEGIN
+        PRINT(1)
+    END
+    ELSE
+    BEGIN
+        PRINT(0)
+    END
+END
+ELSE
+BEGIN
+    PRINT('SQL Server version is lower than 15; check skipped.')
+END

--- a/tests/templates/ag_is_reuse_system_db.j2
+++ b/tests/templates/ag_is_reuse_system_db.j2
@@ -1,0 +1,12 @@
+IF EXISTS (
+  SELECT name
+  FROM sys.databases
+  WHERE name in ('{{ mssql_ha_ag_name }}_master','{{ mssql_ha_ag_name }}_msdb')
+)
+BEGIN
+  PRINT(1)
+END
+ELSE
+BEGIN
+  PRINT(0)
+END

--- a/tests/templates/alter_ag.j2
+++ b/tests/templates/alter_ag.j2
@@ -13,7 +13,7 @@ BEGIN
   )
   BEGIN
     ALTER AVAILABILITY GROUP {{ mssql_ha_ag_name }} SET (DB_FAILOVER = ON)
-    PRINT 'Set DB_FAILOVER to ON succesfully'
+    PRINT 'Set DB_FAILOVER to ON successfully'
   END
   ELSE
   BEGIN

--- a/tests/templates/drop_ag.j2
+++ b/tests/templates/drop_ag.j2
@@ -4,7 +4,7 @@ IF EXISTS (
   WHERE name = '{{ mssql_ha_ag_name }}'
 )
 BEGIN
-  DROP AVAILABILITY GROUP ag1;
+  DROP AVAILABILITY GROUP [{{ mssql_ha_ag_name }}];
   PRINT 'The {{ mssql_ha_ag_name }} availability group dropped successfully';
 END
 ELSE

--- a/tests/templates/drop_dbs.j2
+++ b/tests/templates/drop_dbs.j2
@@ -1,0 +1,16 @@
+{% for db in __mssql_rm_dbs %}
+IF EXISTS(
+  SELECT name
+  FROM sys.databases
+  WHERE name = '{{ db }}'
+)
+BEGIN
+  PRINT 'Dropping the {{ db }} database';
+  DROP DATABASE {{ db }};
+  PRINT 'The {{ db }} database dropped successfully';
+END
+ELSE
+BEGIN
+  PRINT 'The {{ db }} database does not exist, skipping';
+END
+{% endfor %}

--- a/tests/tests_configure_ha_cluster_external.yml
+++ b/tests/tests_configure_ha_cluster_external.yml
@@ -15,7 +15,6 @@
 - name: Verify HA functionality with external clusters and templates
   hosts: all
   vars:
-    __mssql_single_node_test: "{{ ansible_play_hosts_all | length == 1 }}"
     mssql_debug: true
     mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
@@ -41,7 +40,7 @@
     mssql_ha_ag_cluster_type: external
     mssql_ha_login: ExampleLogin
     mssql_ha_login_password: "p@55w0rD3"
-    mssql_ha_virtual_ip: 192.168.122.148
+    mssql_ha_virtual_ip: 192.168.124.222
     # ha_cluster doesn't support running against a single host
     mssql_manage_ha_cluster: "{{ ansible_play_hosts_all | length > 1 }}"
     ha_cluster_cluster_name: "{{ mssql_ha_ag_name }}"
@@ -105,59 +104,9 @@
   tasks:
     - name: Run test in a block to clean up in always
       block:
-        - name: Verify that by default the role fails on EL < 8
-          when:
-            - ansible_distribution in ['CentOS', 'RedHat']
-            - ansible_distribution_version is version('8', '<')
-          block:
-            - name: Run the role
-              vars:
-                mssql_ha_configure: true
-              include_role:
-                name: linux-system-roles.mssql
-
-            - name: Unreachable task
-              fail:
-                msg: The above task must fail
-          rescue:
-            - name: Assert that the role failed with EL 7 not supported
-              assert:
-                that: >-
-                  'mssql_ha_configure=true does not support running against EL 7
-                  hosts' in ansible_failed_result.msg
-          always:
-            - name: Clean up after the role invocation
-              include_tasks: tasks/cleanup.yml
-              when: ansible_play_hosts_all | length == 1
-
-            # Putting end_host into a rescue block results in a failed task
-            - name: End EL 7 host
-              meta: end_host
-
-        - name: Verify that the role fails when primary node is not specified
-          when: ansible_play_hosts_all | length == 1
-          block:
-            - name: Run role with mssql_replica_type=primary not defined
-              include_role:
-                name: linux-system-roles.mssql
-
-            - name: Unreachable task
-              fail:
-                msg: The above task must fail
-          rescue:
-            - name: Assert that the role failed with EL < 8 not supported
-              assert:
-                that: >-
-                  'You must set the mssql_ha_replica_type variable to one of
-                  primary, synchronous, asynchronous, witness, absent'
-                  in ansible_failed_result.msg
-
-        - name: Set the mssql_ha_replica_type fact to appear in hostvars
-          set_fact:
-            mssql_ha_replica_type: primary
-          when:
-            - ansible_play_hosts_all | length == 1
-            - mssql_ha_replica_type is not defined
+        - name: This test is applicable in multi-host scenario only
+          meta: end_play
+          when: ansible_play_hosts_all | length < 3
 
         - name: Load softdog module for stonith to have at least one watchdog
           command: modprobe softdog
@@ -175,828 +124,140 @@
             name: fedora.linux_system_roles.ha_cluster
             tasks_from: test_setup.yml
 
-        - name: Run on all hosts to configure HA cluster
+        - name: Test is_contained functionality available on newers SQL version
+          when: mssql_version is version('2022', '>=')
+          block:
+            - name: Run on all hosts to configure contained AG
+              vars:
+                mssql_ha_ag_is_contained: true
+                mssql_ha_ag_reuse_system_db: false
+              include_role:
+                name: linux-system-roles.mssql
+                public: true
+
+            - name: Verify is_contained status
+              when: __mssql_ha_is_primary | bool
+              include_tasks: tasks/verify_contained.yml
+              vars:
+                __mssql_is_contained: 1
+
+            - name: Clean up AG
+              include_tasks: tasks/cleanup_ag.yml
+
+            - name: Unset create_db facts
+              set_fact:
+                mssql_pre_input_sql_file: []
+
+            - name: Run with contained=true reuse_system_db=true
+              vars:
+                mssql_ha_ag_is_contained: true
+                mssql_ha_ag_reuse_system_db: true
+              include_role:
+                name: linux-system-roles.mssql
+                public: true
+
+            - name: Verify is_contained status
+              when: __mssql_ha_is_primary | bool
+              include_tasks: tasks/verify_contained.yml
+              vars:
+                __mssql_is_contained: 1
+
+            - name: Clean up AG
+              include_tasks: tasks/cleanup_ag.yml
+
+        - name: Run with contained=false
           include_role:
             name: linux-system-roles.mssql
+          vars:
+            mssql_ha_ag_is_contained: false
 
-        - name: Assert that pcs runs properly when testing against >3 nodes
-          when: ansible_play_hosts_all | length >= 3
-          block:
-            - name: Wait for the cluster to finish configuration
-              command: crm_resource --wait
-              changed_when: false
-              when: mssql_manage_ha_cluster | bool
-              register: __mssql_crm_resource_wait
-              until: __mssql_crm_resource_wait is success
-
-            - name: Get global pcs status
-              command: pcs status
-              register: __pcs_status
-              changed_when: false
-
-            - name: Print global psc status
-              debug:
-                var: __pcs_status.stdout
-              run_once: true
-
-            - name: Get pcs status for the virtualip resource
-              command: pcs status resources virtualip
-              register: __pcs_status_virtualip
-              changed_when: false
-
-            - name: Print pcs status for the virtualip resource
-              debug:
-                var: __pcs_status_virtualip.stdout
-              run_once: true
-
-            - name: Assert that virtualip is successfully started
-              assert:
-                that: "'Started' in __pcs_status_virtualip.stdout"
-
-            - name: Move the virtualip resource
-              command: >-
-                pcs resource
-                {% if (ansible_distribution in ['CentOS', 'RedHat']) and
-                (ansible_distribution_major_version is version('9', '>=')) %}
-                move-with-constraint
-                {% else %}
-                move
-                {% endif %}
-                virtualip
-              register: __pcs_move
-              run_once: true
-              changed_when: true
-
-            - name: Wait for the cluster to finish configuration
-              command: crm_resource --wait
-              changed_when: false
-              when: mssql_manage_ha_cluster | bool
-              register: __mssql_crm_resource_wait
-              until: __mssql_crm_resource_wait is success
-
-            - name: Get global pcs status
-              command: pcs status resources
-              register: __pcs_status
-              changed_when: false
-
-            - name: Print global psc status
-              debug:
-                var: __pcs_status.stdout
-              run_once: true
-
-            - name: Get pcs status for the virtualip resource
-              command: pcs status resources virtualip
-              register: __pcs_status_virtualip
-              changed_when: false
-
-            - name: Print pcs status for the virtualip resource
-              debug:
-                var: __pcs_status_virtualip.stdout
-              run_once: true
-
-            - name: Assert that virtualip is successfully started
-              assert:
-                that: "'Started' in __pcs_status_virtualip.stdout"
-
-            - name: Clear constraints for the virtualip resource
-              command: pcs resource clear virtualip
-              changed_when: true
-
-        # The following tasks test if templates configure systems correctly
-        # Because CI runs on a single node, these templates can't be tested:
-        # * remove_from_ag.j2
-        # * join_to_ag.j2
-        # * removing and adding replicas in configure_ag.j2
-        - name: >-
-            Don't test templates when testing against multiple hosts.
-            Testing templates only supported for primary replicas
-          meta: end_play
-          when: >-
-            (ansible_play_hosts_all | length > 1)
-            or
-            (mssql_ha_replica_type | d('primary') != 'primary')
-
-        - name: Set the mssql_ha_replica_type fact to appear in hostvars
-          set_fact:
-            mssql_ha_replica_type: primary
+        - name: Verify is_contained and reuse_system_db status
+          include_tasks: tasks/verify_contained.yml
           when:
-            - ansible_play_hosts_all | length == 1
-            - mssql_ha_replica_type is not defined
-
-        # enable_alwayson.j2 template test
-        - name: Enable AlwaysOn event session when it's enabled
+            - mssql_version is version('2022', '>=')
+            - __mssql_ha_is_primary | bool
           vars:
-            # noqa var-naming[no-role-prefix]
-            __mssql_sql_files_to_input:
-              - enable_alwayson.j2
-          include_role:
-            name: linux-system-roles.mssql
-            tasks_from: input_sql_files.yml
-            public: true
+            __mssql_is_contained: 0
 
-        - name: Assert that enabling is skipped
+        - name: Wait for the cluster to finish configuration
+          command: crm_resource --wait
+          changed_when: false
+          when: mssql_manage_ha_cluster | bool
+          register: __mssql_crm_resource_wait
+          until: __mssql_crm_resource_wait is success
+
+        - name: Get global pcs status
+          command: pcs status
+          register: __pcs_status
+          changed_when: false
+
+        - name: Print global psc status
+          debug:
+            var: __pcs_status.stdout
+          run_once: true
+
+        - name: Get pcs status for the virtualip resource
+          command: pcs status resources virtualip
+          register: __pcs_status_virtualip
+          changed_when: false
+
+        - name: Print pcs status for the virtualip resource
+          debug:
+            var: __pcs_status_virtualip.stdout
+          run_once: true
+
+        - name: Assert that virtualip is successfully started
           assert:
-            that: >-
-              "AlwaysOn Health events already enabled, skipping"
-              in __mssql_sqlcmd_input.stdout
+            that: "'Started' in __pcs_status_virtualip.stdout"
 
-        - name: Disable AlwaysOn event session
-          vars:
-            # noqa var-naming[no-role-prefix]
-            __mssql_sql_files_to_input:
-              - disable_alwayson.j2
-          include_role:
-            name: linux-system-roles.mssql
-            tasks_from: input_sql_files.yml
+        - name: Move the virtualip resource
+          command: >-
+            pcs resource
+            {% if (ansible_distribution in ['CentOS', 'RedHat']) and
+            (ansible_distribution_major_version is version('9', '>=')) %}
+            move-with-constraint
+            {% else %}
+            move
+            {% endif %}
+            virtualip
+          register: __pcs_move
+          run_once: true
+          changed_when: true
 
-        - name: Enable AlwaysOn event session
-          vars:
-            # noqa var-naming[no-role-prefix]
-            __mssql_sql_files_to_input:
-              - enable_alwayson.j2
-          include_role:
-            name: linux-system-roles.mssql
-            tasks_from: input_sql_files.yml
+        - name: Wait for the cluster to finish configuration
+          command: crm_resource --wait
+          changed_when: false
+          when: mssql_manage_ha_cluster | bool
+          register: __mssql_crm_resource_wait
+          until: __mssql_crm_resource_wait is success
 
-        - name: Assert that the template reported changed state
+        - name: Get global pcs status
+          command: pcs status resources
+          register: __pcs_status
+          changed_when: false
+
+        - name: Print global psc status
+          debug:
+            var: __pcs_status.stdout
+          run_once: true
+
+        - name: Get pcs status for the virtualip resource
+          command: pcs status resources virtualip
+          register: __pcs_status_virtualip
+          changed_when: false
+
+        - name: Print pcs status for the virtualip resource
+          debug:
+            var: __pcs_status_virtualip.stdout
+          run_once: true
+
+        - name: Assert that virtualip is successfully started
           assert:
-            that: >-
-              "AlwaysOn Health events enabled successfully"
-              in __mssql_sqlcmd_input.stdout
+            that: "'Started' in __pcs_status_virtualip.stdout"
 
-        # configure_endpoint.j2 template test
-        - name: Create endpoint when it exists
-          vars:
-            # noqa var-naming[no-role-prefix]
-            __mssql_sql_files_to_input:
-              - configure_endpoint.j2
-          include_role:
-            name: linux-system-roles.mssql
-            tasks_from: input_sql_files.yml
-
-        - name: Assert expected messages
-          assert:
-            that:
-              - >-
-                "Verifying the existing endpoint {{ mssql_ha_endpoint_name }}"
-                in __mssql_sqlcmd_input.stdout
-              - >-
-                "The LISTENER_PORT setting for the {{ mssql_ha_endpoint_name }}
-                endpoint is already set to {{ mssql_ha_endpoint_port }},
-                skipping"
-                in __mssql_sqlcmd_input.stdout
-              - >-
-                "The ROLE setting for the {{ mssql_ha_endpoint_name }} endpoint
-                is already set to {{ __mssql_ha_endpoint_role }}, skipping"
-                in __mssql_sqlcmd_input.stdout
-              - >-
-                "The certificate for the {{ mssql_ha_endpoint_name }}
-                endpoint is already set to {{ mssql_ha_cert_name }}, skipping"
-                in __mssql_sqlcmd_input.stdout
-              - >-
-                "The ENCRYPTION setting for the {{ mssql_ha_endpoint_name }}
-                endpoint is already set to AES, skipping"
-                in __mssql_sqlcmd_input.stdout
-              - >-
-                "Endpoint {{ mssql_ha_endpoint_name }} is already started,
-                skipping"
-                in __mssql_sqlcmd_input.stdout
-
-        - name: Alter endpoint to test how template handles incorrect endpoint
-          vars:
-            # noqa var-naming[no-role-prefix]
-            __mssql_sql_files_to_input:
-              - alter_endpoint.j2
-          include_role:
-            name: linux-system-roles.mssql
-            tasks_from: input_sql_files.yml
-
-        - name: Configure endpoint correctly
-          vars:
-            # noqa var-naming[no-role-prefix]
-            __mssql_sql_files_to_input:
-              - configure_endpoint.j2
-          include_role:
-            name: linux-system-roles.mssql
-            tasks_from: input_sql_files.yml
-
-        - name: Assert expected messages
-          assert:
-            that:
-              - >-
-                "Verifying the existing endpoint {{ mssql_ha_endpoint_name }}"
-                in __mssql_sqlcmd_input.stdout
-              - >-
-                "The LISTENER_PORT setting for the {{ mssql_ha_endpoint_name }}
-                endpoint updated to {{ mssql_ha_endpoint_port }} successfully"
-                in __mssql_sqlcmd_input.stdout
-              - >-
-                "The ROLE setting for the {{ mssql_ha_endpoint_name }}
-                endpoint updated to {{ __mssql_ha_endpoint_role }} successfully"
-                in __mssql_sqlcmd_input.stdout
-              - >-
-                "The certificate for the {{ mssql_ha_endpoint_name }}
-                endpoint updated to {{ mssql_ha_cert_name }} successfully"
-                in __mssql_sqlcmd_input.stdout
-              - >-
-                "The ENCRYPTION setting for the {{ mssql_ha_endpoint_name }}
-                endpoint updated to AES successfully"
-                in __mssql_sqlcmd_input.stdout
-              - >-
-                "Endpoint {{ mssql_ha_endpoint_name }} started successfully"
-                in __mssql_sqlcmd_input.stdout
-
-        - name: Drop the test_cert certificate
-          vars:
-            # noqa var-naming[no-role-prefix]
-            __mssql_sql_files_to_input:
-              - drop_cert.j2
-            mssql_ha_cert_name: test_cert
-          include_role:
-            name: linux-system-roles.mssql
-            tasks_from: input_sql_files.yml
-
-        # # configure_listener.j2 template test
-        # - name: Remove a listener for test purposes
-        #   vars:
-        #     # noqa var-naming[no-role-prefix]
-        #     __mssql_sql_files_to_input:
-        #       - remove_listener.j2
-        #   include_role:
-        #     name: linux-system-roles.mssql
-        #     tasks_from: input_sql_files.yml
-
-        # - name: Add a listener with a different name
-        #   vars:
-        #     # noqa var-naming[no-role-prefix]
-        #     __mssql_sql_files_to_input:
-        #       - add_test_listener.j2
-        #   include_role:
-        #     name: linux-system-roles.mssql
-        #     tasks_from: input_sql_files.yml
-
-        # - name: Modify a listener
-        #   vars:
-        #     # noqa var-naming[no-role-prefix]
-        #     __mssql_sql_files_to_input:
-        #       - configure_listener.j2
-        #     mssql_tcp_port: 1435
-        #     mssql_ha_virtual_ip: 192.168.122.149
-        #   include_role:
-        #     name: linux-system-roles.mssql
-        #     tasks_from: input_sql_files.yml
-
-        # - name: Assert expected messages
-        #   assert:
-        #     that:
-        #       - >-
-        #         "Verifying the existing listener TEST-listener"
-        #         in __mssql_sqlcmd_input.stdout
-        #       - >-
-        #         "Modifying the listener port setting"
-        #         in __mssql_sqlcmd_input.stdout
-        #       - >-
-        #         "Set listener port to 1435 successfully"
-        #         in __mssql_sqlcmd_input.stdout
-        #       - >-
-        #         "Modifying the listener ip address setting"
-        #         in __mssql_sqlcmd_input.stdout
-        #       - >-
-        #         "Added listener ip address 192.168.122.149,255.255.255.0
-        #         successfully"
-        #         in __mssql_sqlcmd_input.stdout
-
-        # - name: Remove a listener to re-create with default values
-        #   vars:
-        #     # noqa var-naming[no-role-prefix]
-        #     __mssql_sql_files_to_input:
-        #       - remove_listener.j2
-        #     mssql_listener_name: TEST
-        #   include_role:
-        #     name: linux-system-roles.mssql
-        #     tasks_from: input_sql_files.yml
-
-        # - name: Add a listener with previous settings
-        #   vars:
-        #     # noqa var-naming[no-role-prefix]
-        #     __mssql_sql_files_to_input:
-        #       - configure_listener.j2
-        #   include_role:
-        #     name: linux-system-roles.mssql
-        #     tasks_from: input_sql_files.yml
-
-        # - name: Assert expected messages
-        #   assert:
-        #     that:
-        #       - >-
-        #         "Adding the {{ mssql_ha_ag_name }}-listener listener to the
-        #         {{ mssql_ha_ag_name }} availability group"
-        #         in __mssql_sqlcmd_input.stdout
-        #       - >-
-        #         "Added the {{ mssql_ha_ag_name }}-listener listener
-        #         successfully"
-        #         in __mssql_sqlcmd_input.stdout
-
-        - name: Add a listener when it exists
-          vars:
-            # noqa var-naming[no-role-prefix]
-            __mssql_sql_files_to_input:
-              - configure_listener.j2
-          include_role:
-            name: linux-system-roles.mssql
-            tasks_from: input_sql_files.yml
-
-        - name: Assert expected messages
-          assert:
-            that:
-              - >-
-                "Verifying the existing listener
-                {{ mssql_ha_ag_name }}-listener"
-                in __mssql_sqlcmd_input.stdout
-              - >-
-                "The port setting is already set correctly, skipping"
-                in __mssql_sqlcmd_input.stdout
-              - >-
-                "The listener ip address setting is already set correctly,
-                skipping"
-                in __mssql_sqlcmd_input.stdout
-
-        # create_master_key_encryption.j2 template test
-        - name: Create a master key when it exists
-          vars:
-            # noqa var-naming[no-role-prefix]
-            __mssql_sql_files_to_input:
-              - create_master_key_encryption.j2
-          include_role:
-            name: linux-system-roles.mssql
-            tasks_from: input_sql_files.yml
-
-        - name: Assert that creating is skipped
-          assert:
-            that: >-
-              "The provided master key password is correct"
-              in __mssql_sqlcmd_input.stdout
-
-        - name: Verify creating master key with incorrect password
-          block:
-            - name: Try creating master key with incorrect password
-              vars:
-                # noqa var-naming[no-role-prefix]
-                __mssql_sql_files_to_input:
-                  - create_master_key_encryption.j2
-                mssql_ha_master_key_password: "p@55w0rD11"
-              include_role:
-                name: linux-system-roles.mssql
-                tasks_from: input_sql_files.yml
-
-            - name: This task shouldn't execute
-              fail:
-          rescue:
-            - name: Assert the incorrect password error message
-              assert:
-                that: >-
-                  "You provided an incorrect master key password"
-                  in __mssql_sqlcmd_input.stdout
-
-        - name: Drop endpoint
-          vars:
-            # noqa var-naming[no-role-prefix]
-            __mssql_sql_files_to_input:
-              - create_master_key_encryption.j2
-          include_role:
-            name: linux-system-roles.mssql
-            tasks_from: input_sql_files.yml
-
-        - name: Remove certs from SQL Server to verify re-creating master key
-          vars:
-            # noqa var-naming[no-role-prefix]
-            __mssql_sql_files_to_input:
-              - drop_cert.j2
-          include_role:
-            name: linux-system-roles.mssql
-            tasks_from: input_sql_files.yml
-
-        - name: Remove certificate and private key
-          file:
-            path: "{{ item }}"
-            state: absent
-          loop:
-            - "{{ __mssql_ha_cert_dest }}"
-            - "{{ __mssql_ha_private_key_dest }}"
-
-        - name: >-
-            Verify creating master key with incorrect password and
-            mssql_ha_reset_cert set to true
-          vars:
-            # noqa var-naming[no-role-prefix]
-            __mssql_sql_files_to_input:
-              - create_master_key_encryption.j2
-            mssql_ha_master_key_password: "p@55w0rD11"
-            mssql_ha_reset_cert: true
-          include_role:
-            name: linux-system-roles.mssql
-            tasks_from: input_sql_files.yml
-
-        - name: Assert the expected error message
-          assert:
-            that:
-              - >-
-                "dropping master key to re-create it"
-                in __mssql_sqlcmd_input.stdout
-              - >-
-                "Master key dropped successfully"
-                in __mssql_sqlcmd_input.stdout
-              - >-
-                "Master key created successfully"
-                in __mssql_sqlcmd_input.stdout
-
-        # # restore_cert.j2 template test
-        # - name: Create a certificate when it exists on secondary
-        #   when: mssql_ha_replica_type in ['synchronous', 'witness']
-        #   block:
-        #     - name: Input restore_cert.j2
-        #       vars:
-        #         __mssql_sql_files_to_input:
-        #           - restore_cert.j2
-        #       include_role:
-        #         name: linux-system-roles.mssql
-        #         tasks_from: input_sql_files.yml
-
-        #     - name: Assert the already exists message
-        #       assert:
-        #         that: >-
-        #           "Certificate {{ mssql_ha_cert_name }} already exists,
-        #           skipping"
-        #           in __mssql_sqlcmd_input.stdout
-
-        # create_and_back_up_cert.j2 template test
-        - name: Create and back up an existing and backed up certificate
-          when: mssql_ha_replica_type == 'primary'
-          block:
-            - name: Input create_and_back_up_cert.j2 to create cert
-              vars:
-                # noqa var-naming[no-role-prefix]
-                __mssql_sql_files_to_input:
-                  - create_and_back_up_cert.j2
-              include_role:
-                name: linux-system-roles.mssql
-                tasks_from: input_sql_files.yml
-
-            - name: Assert created successfully messages
-              assert:
-                that:
-                  - >-
-                    "Certificate {{ mssql_ha_cert_name }} created successfully"
-                    in __mssql_sqlcmd_input.stdout
-                  - >-
-                    "{{ __mssql_ha_cert_dest }} and
-                    {{ __mssql_ha_private_key_dest }} exported successfully"
-                    in __mssql_sqlcmd_input.stdout
-
-            - name: Input create_and_back_up_cert.j2 when cert exists
-              vars:
-                # noqa var-naming[no-role-prefix]
-                __mssql_sql_files_to_input:
-                  - create_and_back_up_cert.j2
-              include_role:
-                name: linux-system-roles.mssql
-                tasks_from: input_sql_files.yml
-
-            - name: Assert task skipping messages
-              assert:
-                that:
-                  - >-
-                    "Certificate {{ mssql_ha_cert_name }} already exists,
-                    skipping"
-                    in __mssql_sqlcmd_input.stdout
-                  - >-
-                    "{{ __mssql_ha_cert_dest }} and
-                    {{ __mssql_ha_private_key_dest }} already exist, skipping"
-                    in __mssql_sqlcmd_input.stdout
-
-            - name: Back up certificate and private key
-              copy:
-                remote_src: true
-                src: "{{ item }}"
-                dest: /tmp/{{ item | basename }}
-                mode: "0600"
-              loop:
-                - "{{ __mssql_ha_cert_dest }}"
-                - "{{ __mssql_ha_private_key_dest }}"
-
-            - name: Remove private key
-              file:
-                path: "{{ __mssql_ha_private_key_dest }}"
-                state: absent
-
-            - name: Input create_and_back_up_cert.j2
-              vars:
-                # noqa var-naming[no-role-prefix]
-                __mssql_sql_files_to_input:
-                  - create_and_back_up_cert.j2
-              include_role:
-                name: linux-system-roles.mssql
-                tasks_from: input_sql_files.yml
-
-            - name: Assert expected error messages
-              assert:
-                that:
-                  - >-
-                    "Certificate {{ mssql_ha_cert_name }} already exists,
-                    skipping"
-                    in __mssql_sqlcmd_input.stdout
-                  - >-
-                    "{{ __mssql_ha_private_key_dest }} does not exist while
-                    {{ __mssql_ha_cert_dest }} exists."
-                    in __mssql_sqlcmd_input.stdout
-
-            - name: Remove certificate
-              file:
-                path: "{{ __mssql_ha_cert_dest }}"
-                state: absent
-
-            - name: Return private key
-              copy:
-                remote_src: true
-                src: /tmp/{{ __mssql_ha_private_key_dest | basename }}
-                dest: "{{ __mssql_ha_private_key_dest }}"
-                mode: "0600"
-
-            - name: Input create_and_back_up_cert.j2
-              vars:
-                # noqa var-naming[no-role-prefix]
-                __mssql_sql_files_to_input:
-                  - create_and_back_up_cert.j2
-              include_role:
-                name: linux-system-roles.mssql
-                tasks_from: input_sql_files.yml
-
-            - name: Assert expected error messages
-              assert:
-                that:
-                  - >-
-                    "Certificate {{ mssql_ha_cert_name }} already exists,
-                    skipping"
-                    in __mssql_sqlcmd_input.stdout
-                  - >-
-                    "{{ __mssql_ha_cert_dest }} does not exist while
-                    {{ __mssql_ha_private_key_dest }} exists."
-                    in __mssql_sqlcmd_input.stdout
-
-            - name: Return certificate
-              copy:
-                remote_src: true
-                src: /tmp/{{ __mssql_ha_cert_dest | basename }}
-                dest: "{{ __mssql_ha_cert_dest }}"
-                mode: "0600"
-
-            - name: Drop certificate from SQL Server
-              vars:
-                # noqa var-naming[no-role-prefix]
-                __mssql_sql_files_to_input:
-                  - drop_cert.j2
-              include_role:
-                name: linux-system-roles.mssql
-                tasks_from: input_sql_files.yml
-
-            - name: Create cert when cert files exist and SQL cert does not
-              block:
-                - name: Input create_and_back_up_cert.j2
-                  vars:
-                    # noqa var-naming[no-role-prefix]
-                    __mssql_sql_files_to_input:
-                      - create_and_back_up_cert.j2
-                  include_role:
-                    name: linux-system-roles.mssql
-                    tasks_from: input_sql_files.yml
-
-                - name: Unreachable task
-                  fail:
-                    msg: The above task must fail
-              rescue:
-                - name: Assert expected error messages
-                  assert:
-                    that:
-                      - >-
-                        "Certificate {{ mssql_ha_cert_name }} does not exist in
-                        SQL Server, however, {{ __mssql_ha_cert_dest }} and/or
-                        {{ __mssql_ha_private_key_dest }} files do exist."
-                        in __mssql_sqlcmd_input.stdout
-
-            - name: Remove certificate and private key
-              file:
-                path: "{{ item }}"
-                state: absent
-              loop:
-                - "{{ __mssql_ha_cert_dest }}"
-                - "{{ __mssql_ha_private_key_dest }}"
-
-            - name: Ensure that certificates exist
-              vars:
-                # noqa var-naming[no-role-prefix]
-                __mssql_sql_files_to_input:
-                  - create_and_back_up_cert.j2
-              include_role:
-                name: linux-system-roles.mssql
-                tasks_from: input_sql_files.yml
-
-            - name: Assert expected messages
-              assert:
-                that: >-
-                  "Certificate {{ mssql_ha_cert_name }} created successfully"
-                  in __mssql_sqlcmd_input.stdout
-
-        # create_ha_login.j2 template test
-        - name: Create a login when it already exists {{ mssql_ha_login }}
-          vars:
-            # noqa var-naming[no-role-prefix]
-            __mssql_sql_files_to_input:
-              - create_ha_login.j2
-          include_role:
-            name: linux-system-roles.mssql
-            tasks_from: input_sql_files.yml
-
-        - name: Assert task skipping messages
-          assert:
-            that:
-              - >-
-                "A {{ mssql_ha_login }} login already exists, skipping"
-                in __mssql_sqlcmd_input.stdout
-              - >-
-                "{{ mssql_ha_login }} is a member of sysadmin role, skipping"
-                in __mssql_sqlcmd_input.stdout
-
-        # replicate_db.j2 template test
-        - name: Replicate database what it is already replicated
-          when: mssql_ha_replica_type == 'primary'
-          block:
-            - name: Input replicate_db.j2
-              vars:
-                # noqa var-naming[no-role-prefix]
-                __mssql_sql_files_to_input:
-                  - replicate_db.j2
-              include_role:
-                name: linux-system-roles.mssql
-                tasks_from: input_sql_files.yml
-
-            - name: Assert task skipping messages
-              assert:
-                that:
-                  - >-
-                    "RECOVERY FULL on the ExampleDB1 database is set, skipping"
-                    in __mssql_sqlcmd_input.stdout
-                  - >-
-                    "The ExampleDB1 database is already backed up, skipping"
-                    in __mssql_sqlcmd_input.stdout
-                  - >-
-                    "The ExampleDB1 database is already added to the ExampleAG
-                    availability group, skipping"
-                    in __mssql_sqlcmd_input.stdout
-                  - >-
-                    "RECOVERY FULL on the ExampleDB2 database is set, skipping"
-                    in __mssql_sqlcmd_input.stdout
-                  - >-
-                    "The ExampleDB2 database is already backed up, skipping"
-                    in __mssql_sqlcmd_input.stdout
-                  - >-
-                    "The ExampleDB2 database is already added to the ExampleAG
-                    availability group, skipping"
-                    in __mssql_sqlcmd_input.stdout
-
-        # configure_ag.yml template test
-        - name: Ensure endpoint exists
-          vars:
-            # noqa var-naming[no-role-prefix]
-            __mssql_sql_files_to_input:
-              - configure_endpoint.j2
-          include_role:
-            name: linux-system-roles.mssql
-            tasks_from: input_sql_files.yml
-
-        - name: Test configure_ag.yml on primary
-          when: mssql_ha_replica_type == 'primary'
-          block:
-            - name: Input configure_ag.yml when AG exists
-              vars:
-                # noqa var-naming[no-role-prefix]
-                __mssql_sql_files_to_input:
-                  - configure_ag.j2
-              include_role:
-                name: linux-system-roles.mssql
-                tasks_from: input_sql_files.yml
-
-            - name: Assert task skipping messages
-              assert:
-                that:
-                  - >-
-                    "DB_FAILOVER = ON is already set, skipping"
-                    in __mssql_sqlcmd_input.stdout
-                  - >-
-                    "The ENDPOINT_URL setting on this
-                    {{ mssql_ha_replica_type }} replica is already set
-                    correctly, skipping"
-                    in __mssql_sqlcmd_input.stdout
-                  - >-
-                    "The FAILOVER_MODE setting on this
-                    {{ mssql_ha_replica_type }} replica is already set
-                    correctly, skipping"
-                    in __mssql_sqlcmd_input.stdout
-                  - >-
-                    "The SEEDING_MODE setting on this
-                    {{ mssql_ha_replica_type }} replica is already set
-                    correctly, skipping"
-                    in __mssql_sqlcmd_input.stdout
-                  - >-
-                    "The SECONDARY_ROLE (ALLOW_CONNECTIONS = ALL) setting on
-                    this {{ mssql_ha_replica_type }} replica is already set
-                    correctly"
-                    in __mssql_sqlcmd_input.stdout
-
-            # Using mssql_ha_ag_name: ag2 because running tasks against ag1
-            # fails with "Replica not Primary"
-            - name: Verify configuration of a new ag2
-              vars:
-                # noqa var-naming[no-role-prefix]
-                __mssql_sql_files_to_input:
-                  - configure_ag_cluster_type_none.j2
-                mssql_ha_ag_name: ag2
-              block:
-                - name: Configure AG with CLUSTER_TYPE = NONE
-                  include_role:
-                    name: linux-system-roles.mssql
-                    tasks_from: input_sql_files.yml
-
-                - name: Input configure_ag.yml with CLUSTER_TYPE = NONE
-                  vars:
-                    # noqa var-naming[no-role-prefix]
-                    __mssql_sql_files_to_input:
-                      - configure_ag.j2
-                  include_role:
-                    name: linux-system-roles.mssql
-                    tasks_from: input_sql_files.yml
-
-                - name: Assert task skipping messages
-                  assert:
-                    that:
-                      - >-
-                        "The existing {{ mssql_ha_ag_name }} availability group
-                        has incorrect cluster type set, dropping the group to
-                        re-create it"
-                        in __mssql_sqlcmd_input.stdout
-                      - >-
-                        "The {{ mssql_ha_ag_name }} availability group dropped
-                        successfully"
-                        in __mssql_sqlcmd_input.stdout
-                      - >-
-                        "The {{ mssql_ha_ag_name }} availability group created
-                        successfully"
-                        in __mssql_sqlcmd_input.stdout
-
-                - name: Alter AG
-                  vars:
-                    # noqa var-naming[no-role-prefix]
-                    __mssql_sql_files_to_input:
-                      - alter_ag.j2
-                  include_role:
-                    name: linux-system-roles.mssql
-                    tasks_from: input_sql_files.yml
-
-                - name: Input configure_ag.yml to configure ag properly
-                  vars:
-                    # noqa var-naming[no-role-prefix]
-                    __mssql_sql_files_to_input:
-                      - configure_ag.j2
-                  include_role:
-                    name: linux-system-roles.mssql
-                    tasks_from: input_sql_files.yml
-
-                - name: Assert task skipping messages
-                  assert:
-                    that:
-                      - >-
-                        "Verifying the existing availability group
-                        {{ mssql_ha_ag_name }}"
-                        in __mssql_sqlcmd_input.stdout
-                      - >-
-                        "The ENDPOINT_URL setting on this
-                        {{ mssql_ha_replica_type }} replica configured
-                        successfully"
-                        in __mssql_sqlcmd_input.stdout
-                      - >-
-                        "The FAILOVER_MODE setting on this
-                        {{ mssql_ha_replica_type }} replica is already set
-                        correctly, skipping"
-                        in __mssql_sqlcmd_input.stdout
-                      - >-
-                        "The SEEDING_MODE setting on this
-                        {{ mssql_ha_replica_type }} replica configured
-                        successfully"
-                        in __mssql_sqlcmd_input.stdout
-                      - >-
-                        "The SECONDARY_ROLE (ALLOW_CONNECTIONS = ALL) setting on
-                        this {{ mssql_ha_replica_type }} replica configured
-                        successfully"
-                        in __mssql_sqlcmd_input.stdout
+        - name: Clear constraints for the virtualip resource
+          command: pcs resource clear virtualip
+          changed_when: true
       always:
         - name: Clean up after the role invocation
           include_tasks: tasks/cleanup.yml

--- a/tests/tests_configure_ha_cluster_read_scale.yml
+++ b/tests/tests_configure_ha_cluster_read_scale.yml
@@ -42,6 +42,10 @@
     - name: Run test in a block to clean up in always
       when: ansible_play_hosts_all | length >= 3
       block:
+        - name: This test is applicable in multi-host scenario only
+          meta: end_play
+          when: ansible_play_hosts_all | length < 3
+
         - name: Clusters of a read_scale type must not have a witness node
           meta: end_play
           when: ansible_play_hosts_all |
@@ -49,35 +53,6 @@
             select('match', '^witness$') |
             list |
             length > 0
-
-        - name: Verify that by default the role fails on EL < 8
-          when:
-            - ansible_distribution in ['CentOS', 'RedHat']
-            - ansible_distribution_version is version('8', '<')
-          block:
-            - name: Run the role
-              vars:
-                mssql_ha_configure: true
-              include_role:
-                name: linux-system-roles.mssql
-
-            - name: Unreachable task
-              fail:
-                msg: The above task must fail
-          rescue:
-            - name: Assert that the role failed with EL 7 not supported
-              assert:
-                that: >-
-                  'mssql_ha_configure=true does not support running against EL 7
-                  hosts' in ansible_failed_result.msg
-          always:
-            - name: Clean up after the role invocation
-              include_tasks: tasks/cleanup.yml
-              when: ansible_play_hosts_all | length == 1
-
-            # Putting end_host into a rescue block results in a failed task
-            - name: End EL 7 host
-              meta: end_host
 
         - name: Set facts to create test DBs on primary as a pre task
           set_fact:

--- a/tests/tests_ha_single_2017.yml
+++ b/tests/tests_ha_single_2017.yml
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: MIT
+# Example test inventory:
+# all:
+#   hosts:
+#     managed_host1:
+#       ansible_host: <ip_address1>
+---
+- name: Verify HA functionality with a single-node test
+  hosts: all
+  gather_facts: true
+  vars:
+    __mssql_single_node_test: "{{ ansible_play_hosts_all | length == 1 }}"
+    mssql_debug: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
+    mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
+    mssql_accept_microsoft_sql_server_standard_eula: true
+    mssql_password: "p@55w0rD"
+    mssql_edition: Evaluation
+    mssql_version: 2017
+    mssql_manage_firewall: true
+    __mssql_gather_facts_no_log: true
+    mssql_manage_selinux: false
+    mssql_run_selinux_confined: false
+    mssql_ha_configure: true
+    mssql_ha_endpoint_port: 5022
+    mssql_ha_cert_name: ExampleCert
+    mssql_ha_master_key_password: "p@55w0rD1"
+    mssql_ha_private_key_password: "p@55w0rD2"
+    mssql_ha_reset_cert: false
+    mssql_ha_endpoint_name: Example_Endpoint
+    mssql_ha_ag_name: ExampleAG
+    mssql_ha_db_names:
+      - ExampleDB1
+      - ExampleDB2
+    mssql_ha_ag_cluster_type: external
+    mssql_ha_login: ExampleLogin
+    mssql_ha_login_password: "p@55w0rD3"
+    mssql_ha_virtual_ip: 192.168.122.141
+    mssql_ha_ag_is_contained: false
+    mssql_ha_ag_reuse_system_db: false
+    mssql_manage_ha_cluster: false
+    ha_cluster_cluster_name: "{{ mssql_ha_ag_name }}"
+    ha_cluster_hacluster_password: "p@55w0rD4"
+    ha_cluster_sbd_enabled: true
+    ha_cluster_cluster_properties:
+      - attrs:
+          - name: cluster-recheck-interval
+            value: 2min
+          - name: start-failure-is-fatal
+            value: true
+          - name: stonith-enabled
+            value: true
+          - name: stonith-watchdog-timeout
+            value: 10
+    ha_cluster_resource_primitives:
+      - id: ag_cluster
+        agent: ocf:mssql:ag
+        instance_attrs:
+          - attrs:
+              - name: ag_name
+                value: "{{ mssql_ha_ag_name }}"
+        meta_attrs:
+          - attrs:
+              - name: failure-timeout
+                value: 60s
+      - id: virtualip
+        agent: ocf:heartbeat:IPaddr2
+        instance_attrs:
+          - attrs:
+              - name: ip
+                value: "{{ mssql_ha_virtual_ip }}"
+        operations:
+          - action: monitor
+            attrs:
+              - name: interval
+                value: 30s
+    ha_cluster_resource_clones:
+      - resource_id: ag_cluster
+        promotable: true
+        meta_attrs:
+          - attrs:
+              - name: notify
+                value: true
+    ha_cluster_constraints_colocation:
+      - resource_leader:
+          id: ag_cluster-clone
+          role: Promoted
+        resource_follower:
+          id: virtualip
+        options:
+          - name: score
+            value: INFINITY
+    ha_cluster_constraints_order:
+      - resource_first:
+          id: ag_cluster-clone
+          action: promote
+        resource_then:
+          id: virtualip
+          action: start
+  tasks:
+    - name: Run test in a block to clean up in always
+      block:
+        - name: Run tests_ha_single with SQL Server {{ mssql_version }}
+          include_tasks: tasks/tests_ha_single.yml
+      always:
+        - name: Clean up after the role invocation
+          include_tasks: tasks/cleanup.yml

--- a/tests/tests_ha_single_2019.yml
+++ b/tests/tests_ha_single_2019.yml
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: MIT
+# Example test inventory:
+# all:
+#   hosts:
+#     managed_host1:
+#       ansible_host: <ip_address1>
+---
+- name: Verify HA functionality with a single-node test
+  hosts: all
+  gather_facts: true
+  vars:
+    __mssql_single_node_test: "{{ ansible_play_hosts_all | length == 1 }}"
+    mssql_debug: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
+    mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
+    mssql_accept_microsoft_sql_server_standard_eula: true
+    mssql_password: "p@55w0rD"
+    mssql_edition: Evaluation
+    mssql_version: 2019
+    mssql_manage_firewall: true
+    __mssql_gather_facts_no_log: true
+    mssql_manage_selinux: false
+    mssql_run_selinux_confined: false
+    mssql_ha_configure: true
+    mssql_ha_endpoint_port: 5022
+    mssql_ha_cert_name: ExampleCert
+    mssql_ha_master_key_password: "p@55w0rD1"
+    mssql_ha_private_key_password: "p@55w0rD2"
+    mssql_ha_reset_cert: false
+    mssql_ha_endpoint_name: Example_Endpoint
+    mssql_ha_ag_name: ExampleAG
+    mssql_ha_db_names:
+      - ExampleDB1
+      - ExampleDB2
+    mssql_ha_ag_cluster_type: external
+    mssql_ha_login: ExampleLogin
+    mssql_ha_login_password: "p@55w0rD3"
+    mssql_ha_virtual_ip: 192.168.122.141
+    mssql_ha_ag_is_contained: false
+    mssql_ha_ag_reuse_system_db: false
+    mssql_manage_ha_cluster: false
+    ha_cluster_cluster_name: "{{ mssql_ha_ag_name }}"
+    ha_cluster_hacluster_password: "p@55w0rD4"
+    ha_cluster_sbd_enabled: true
+    ha_cluster_cluster_properties:
+      - attrs:
+          - name: cluster-recheck-interval
+            value: 2min
+          - name: start-failure-is-fatal
+            value: true
+          - name: stonith-enabled
+            value: true
+          - name: stonith-watchdog-timeout
+            value: 10
+    ha_cluster_resource_primitives:
+      - id: ag_cluster
+        agent: ocf:mssql:ag
+        instance_attrs:
+          - attrs:
+              - name: ag_name
+                value: "{{ mssql_ha_ag_name }}"
+        meta_attrs:
+          - attrs:
+              - name: failure-timeout
+                value: 60s
+      - id: virtualip
+        agent: ocf:heartbeat:IPaddr2
+        instance_attrs:
+          - attrs:
+              - name: ip
+                value: "{{ mssql_ha_virtual_ip }}"
+        operations:
+          - action: monitor
+            attrs:
+              - name: interval
+                value: 30s
+    ha_cluster_resource_clones:
+      - resource_id: ag_cluster
+        promotable: true
+        meta_attrs:
+          - attrs:
+              - name: notify
+                value: true
+    ha_cluster_constraints_colocation:
+      - resource_leader:
+          id: ag_cluster-clone
+          role: Promoted
+        resource_follower:
+          id: virtualip
+        options:
+          - name: score
+            value: INFINITY
+    ha_cluster_constraints_order:
+      - resource_first:
+          id: ag_cluster-clone
+          action: promote
+        resource_then:
+          id: virtualip
+          action: start
+  tasks:
+    - name: Run test in a block to clean up in always
+      block:
+        - name: Run tests_ha_single with SQL Server {{ mssql_version }}
+          include_tasks: tasks/tests_ha_single.yml
+      always:
+        - name: Clean up after the role invocation
+          include_tasks: tasks/cleanup.yml

--- a/tests/tests_ha_single_2022.yml
+++ b/tests/tests_ha_single_2022.yml
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: MIT
+# Example test inventory:
+# all:
+#   hosts:
+#     managed_host1:
+#       ansible_host: <ip_address1>
+---
+- name: Verify HA functionality with a single-node test
+  hosts: all
+  gather_facts: true
+  vars:
+    __mssql_single_node_test: "{{ ansible_play_hosts_all | length == 1 }}"
+    mssql_debug: true
+    mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
+    mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
+    mssql_accept_microsoft_sql_server_standard_eula: true
+    mssql_password: "p@55w0rD"
+    mssql_edition: Evaluation
+    mssql_version: 2022
+    mssql_manage_firewall: true
+    __mssql_gather_facts_no_log: true
+    mssql_manage_selinux: false
+    mssql_run_selinux_confined: false
+    mssql_ha_configure: true
+    mssql_ha_endpoint_port: 5022
+    mssql_ha_cert_name: ExampleCert
+    mssql_ha_master_key_password: "p@55w0rD1"
+    mssql_ha_private_key_password: "p@55w0rD2"
+    mssql_ha_reset_cert: false
+    mssql_ha_endpoint_name: Example_Endpoint
+    mssql_ha_ag_name: ExampleAG
+    mssql_ha_db_names:
+      - ExampleDB1
+      - ExampleDB2
+    mssql_ha_ag_cluster_type: external
+    mssql_ha_login: ExampleLogin
+    mssql_ha_login_password: "p@55w0rD3"
+    mssql_ha_virtual_ip: 192.168.122.141
+    mssql_ha_ag_is_contained: false
+    mssql_ha_ag_reuse_system_db: false
+    mssql_manage_ha_cluster: false
+    ha_cluster_cluster_name: "{{ mssql_ha_ag_name }}"
+    ha_cluster_hacluster_password: "p@55w0rD4"
+    ha_cluster_sbd_enabled: true
+    ha_cluster_cluster_properties:
+      - attrs:
+          - name: cluster-recheck-interval
+            value: 2min
+          - name: start-failure-is-fatal
+            value: true
+          - name: stonith-enabled
+            value: true
+          - name: stonith-watchdog-timeout
+            value: 10
+    ha_cluster_resource_primitives:
+      - id: ag_cluster
+        agent: ocf:mssql:ag
+        instance_attrs:
+          - attrs:
+              - name: ag_name
+                value: "{{ mssql_ha_ag_name }}"
+        meta_attrs:
+          - attrs:
+              - name: failure-timeout
+                value: 60s
+      - id: virtualip
+        agent: ocf:heartbeat:IPaddr2
+        instance_attrs:
+          - attrs:
+              - name: ip
+                value: "{{ mssql_ha_virtual_ip }}"
+        operations:
+          - action: monitor
+            attrs:
+              - name: interval
+                value: 30s
+    ha_cluster_resource_clones:
+      - resource_id: ag_cluster
+        promotable: true
+        meta_attrs:
+          - attrs:
+              - name: notify
+                value: true
+    ha_cluster_constraints_colocation:
+      - resource_leader:
+          id: ag_cluster-clone
+          role: Promoted
+        resource_follower:
+          id: virtualip
+        options:
+          - name: score
+            value: INFINITY
+    ha_cluster_constraints_order:
+      - resource_first:
+          id: ag_cluster-clone
+          action: promote
+        resource_then:
+          id: virtualip
+          action: start
+  tasks:
+    - name: Run test in a block to clean up in always
+      block:
+        - name: Run tests_ha_single with SQL Server {{ mssql_version }}
+          include_tasks: tasks/tests_ha_single.yml
+      always:
+        - name: Clean up after the role invocation
+          include_tasks: tasks/cleanup.yml


### PR DESCRIPTION
Feature: add support to create Availability Group (AG) with contained database, and reuse system database

add two new var in playbook:
1、
mssql_ha_ag_is_contained
if true, the ag created will be contained
if false, the var mssql_ha_ag_reuse_system_db will be false
Default: false
Type: bool

2、
mssql_ha_ag_reuse_system_db
if true, the contained ag will be reuse system database
Default: false
Type: bool

Reason:  These are used to specify whether to CONTAINED and REUSE SYSTEM DATABASE when creating new availability group, it's feature in SQL Server 2022 - see the doc from microsoft:
https://learn.microsoft.com/en-us/sql/database-engine/availability-groups/windows/contained-availability-groups-overview?view=sql-server-ver16

Result: Users are able to create contained databases and reuse system databases as per the new features of SQL Server 2022.