### PR TITLE
fix: Prepare for dnf5

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -218,7 +218,7 @@
   when:
     - __mssql_current_version is defined
     - mssql_upgrade | bool
-    - ansible_pkg_mgr in ["yum", "dnf"]
+    - ansible_pkg_mgr in ["yum", "dnf", "dnf5"]
   block:
     # This works only on systems that use yum or dnf
     - name: >-
@@ -291,7 +291,7 @@
     baseurl: "{{ mssql_server_repository }}"
     gpgcheck: true
   when:
-    - ansible_pkg_mgr in ["yum", "dnf"]
+    - ansible_pkg_mgr in ["yum", "dnf", "dnf5"]
     - >-
       (__mssql_server_packages not in ansible_facts.packages) or
       (mssql_upgrade | bool)
@@ -493,7 +493,7 @@
     description: Microsoft SQL Server Tools
     baseurl: "{{ mssql_client_repository }}"
     gpgcheck: true
-  when: ansible_pkg_mgr in ["yum", "dnf"]
+  when: ansible_pkg_mgr in ["yum", "dnf", "dnf5"]
 
 - name: Configure the Microsoft SQL Server Tools repository # noqa command-instead-of-module
   command: >-


### PR DESCRIPTION
`ansible_pkg_mgr` is `dnf5` on Fedora 42 and ELN (i.e. the future RHEL 11).

---

Similar to https://github.com/linux-system-roles/cockpit/pull/205 , thanks @spetrosi for finding this!