### PR TITLE
fix: Make service check work in container environments; plus two other bootc preparation fixes

### DIFF
--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -105,7 +105,7 @@ jobs:
           python3 -m pip install --upgrade pip
           sudo apt update
           sudo apt install -y --no-install-recommends git ansible-core genisoimage qemu-system-x86
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
 
       - name: Configure tox-lsr
         if: steps.check_platform.outputs.supported

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -335,18 +335,27 @@
   register: __mssql_errorlog
   check_mode: false
 
-- name: Gather system services facts
-  service_facts:
-  no_log: "{{ __mssql_gather_facts_no_log | d(false) }}"
+  # service_facts does not work in non-booted systems
+- name: Check if mssql-server.service is enabled
+  # noqa command-instead-of-module
+  command: systemctl is-enabled mssql-server.service
+  register: __mssql_service_enabled
+  changed_when: false
+  failed_when: false
+
+- name: Check if mssql-server.service is running
+  # noqa command-instead-of-module
+  command: systemctl is-active mssql-server.service
+  register: __mssql_service_active
+  changed_when: false
+  failed_when: false
 
 - name: Set the __mssql_is_setup variable
   set_fact:
     __mssql_is_setup: >-
-      {{ ('running' in
-      ansible_facts['services']['mssql-server.service']['state']) or
-      ('enabled' in
-      ansible_facts['services']['mssql-server.service']['status']) or
-      (__mssql_errorlog.stdout | length > 0) }}
+      {{ (__mssql_service_enabled.rc == 0) or
+         (__mssql_service_active.rc == 0) or
+         (__mssql_errorlog.stdout | length > 0) }}
 
 - name: Verify that the variables required for setting up MSSQL are defined
   when: not __mssql_is_setup

--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -63,6 +63,7 @@
     /tmp/*.j2
     /tmp/mssql_data
     /tmp/mssql_log
+    /etc/systemd/system/mssql-server.service.d
     /etc/systemd/system/multi-user.target.wants/mssql-server.service
   register: __mssql_cleanup_remove
   changed_when: "'removed' in __mssql_cleanup_remove.stdout"

--- a/tests/tasks/mssql-sever-increase-start-limit.yml
+++ b/tests/tasks/mssql-sever-increase-start-limit.yml
@@ -1,22 +1,26 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Modify the mssql-server service start limit interval
-  replace:
-    path: /etc/systemd/system/multi-user.target.wants/mssql-server.service
-    regexp: StartLimitInterval.*
-    replace: StartLimitInterval=0
-  register: __mssql_modify_limit_interval
+- name: Create service drop-in directory
+  file:
+    path: /etc/systemd/system/mssql-server.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
 
-- name: Modify the mssql-server service start limit burst
-  replace:
-    path: /etc/systemd/system/multi-user.target.wants/mssql-server.service
-    regexp: StartLimitBurst.*
-    replace: StartLimitBurst=0
-  register: __mssql_modify_limit_burst
+- name: Modify the mssql-server service start limit interval and burst
+  copy:
+    dest: /etc/systemd/system/mssql-server.service.d/startlimit.conf
+    content: |
+      [Service]
+      StartLimitInterval=0
+      StartLimitBurst=0
+    owner: root
+    group: root
+    mode: "0644"
+  register: __mssql_modify_limit
 
 - name: Reload service daemon
   systemd:  # noqa no-handler
     daemon_reload: true
-  when: >
-    (__mssql_modify_limit_interval is changed) or
-    (__mssql_modify_limit_burst is changed)
+  when: __mssql_modify_limit is changed


### PR DESCRIPTION
This is not nearly sufficient yet, but some initial steps which I would like to test and land in isolation -- these shouldn't break the "booted system" case.