### PR TITLE
ci: bump tox-lsr to 3.8.0; rename qemu/kvm tests

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.8.0"
 
       - name: Convert role to collection format
         id: collection

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.8.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.8.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -70,7 +70,7 @@ jobs:
 
           # bootc build support (in buildah) has a separate flag
           if [ "${{ matrix.scenario.image }}" != "$image" ]; then
-            if ! yq -e '.galaxy_info.galaxy_tags[] | select(. == "containerbuild")' meta/main.yml; then
+          if ! yq -e '.galaxy_info.galaxy_tags[] | select(. == "containerbuild")' meta/main.yml; then
               supported=
             fi
           else
@@ -105,7 +105,7 @@ jobs:
           python3 -m pip install --upgrade pip
           sudo apt update
           sudo apt install -y --no-install-recommends git ansible-core genisoimage qemu-system-x86
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.8.0"
 
       - name: Configure tox-lsr
         if: steps.check_platform.outputs.supported
@@ -115,8 +115,9 @@ jobs:
 
       - name: Run qemu integration tests
         if: steps.check_platform.outputs.supported && startsWith(matrix.scenario.env, 'qemu')
-        run: |
-          tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} --make-batch $TOX_ARGS --
+        run: >-
+          tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} --make-batch
+          --log-level=debug --skip-tags tests::infiniband,tests::nvme,tests::scsi --
 
       - name: Qemu result summary
         if: steps.check_platform.outputs.supported && startsWith(matrix.scenario.env, 'qemu') && always()
@@ -175,7 +176,7 @@ jobs:
         run: |
           set -euo pipefail
           for f in tests/*.log; do
-              if FAIL=$(grep -B100 -A30 "fatal:" "$f"); then
+              if FAIL=$(grep -E -B100 -A30 "fatal:|An exception occurred" "$f"); then
                   echo "::group::$(basename $f)"
                   echo "$FAIL"
                   echo "::endgroup::"

--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -96,3 +96,21 @@
     semodule --priority=200 -r mssql
   changed_when: true
   when: "'mssql' in __mssql_policy_loaded.stdout_lines"
+
+- name: Check for leftover mssql processes
+  command: pgrep -au mssql
+  register: __mssql_processes
+  changed_when: false
+  # 0: found, 1: no processes, 2: user mssql does not exist
+  failed_when: not __mssql_processes.rc in [0, 1, 2]
+
+- name: Kill leftover mssql processes
+  command: pkill --signal KILL -e -u mssql
+  changed_when: true
+  when: __mssql_processes.rc == 0
+
+- name: Remove system user
+  user:
+    name: mssql
+    state: absent
+    remove: true

--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -28,6 +28,7 @@
     selinux_all_purge: true
   include_role:
     name: fedora.linux_system_roles.selinux
+  when: mssql_manage_selinux | d(false) | bool
 
 - name: Leave realm
   command: realm leave
@@ -72,3 +73,26 @@
 - name: Stop the mssql-server service  # noqa command-instead-of-module
   shell: systemctl stop mssql-server || true
   changed_when: false
+
+- name: Get SELinux policy modules
+  command: semodule -l
+  changed_when: false
+  register: __mssql_policy_loaded
+
+# not installed in Fedora by default
+- name: Ensure that semanage command is available
+  package:
+    name: policycoreutils-python-utils
+    state: present
+  when: "'mssql' in __mssql_policy_loaded.stdout_lines"
+
+# removing the mssql-server-selinux package fails to actually remove the
+# policy (and ignores the failure)
+- name: Hack around broken mssql SELinux profile and actually remove it
+  shell: |-
+    set -eux
+    semanage fcontext -D
+    semanage port -D
+    semodule --priority=200 -r mssql
+  changed_when: true
+  when: "'mssql' in __mssql_policy_loaded.stdout_lines"

--- a/tests/tasks/verify_settings.yml
+++ b/tests/tasks/verify_settings.yml
@@ -90,11 +90,28 @@
         tasks_from: verify_password
         public: true
 
-    - name: Wait for mssql-server to prepare for client connections
-      wait_for:
-        path: /var/opt/mssql/log/errorlog
-        search_regex: SQL Server is now ready for client connections
-        delay: 1
+    - name: Wait for mssql-server to get ready
+      block:
+        - name: Wait for mssql-server to prepare for client connections
+          wait_for:
+            path: /var/opt/mssql/log/errorlog
+            search_regex: SQL Server is now ready for client connections
+            delay: 1
+      rescue:
+        - name: Show log file for debugging
+          command: cat /var/opt/mssql/log/errorlog
+          changed_when: false
+
+        - name: Show process status
+          shell: |
+            set -euo pipefail
+            systemctl status mssql-server || true
+            pgrep -au mssql || true
+          changed_when: false
+
+        - name: Fail the waiting
+          fail:
+            msg: '"ready for client connections" did not appear in above log'
 
     - name: Check if the set password matches the existing password
       command: "{{ __mssql_sqlcmd_login_cmd }} -Q 'SELECT @@VERSION'"


### PR DESCRIPTION
This will make the qemu/kvm tests be tested in either
ascending or descending ASCII order.  This should give
us better test coverage of clean up scenarios which may
fail depending on the order of the previous tests.

Rename the qemu/kvm tests so that the statuses are shorter
and more intuitive.

Improve qemu/kvm test failure error reporting.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
