### PR TITLE
feat: Support this role in container builds

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,4 @@
   service:
     name: mssql-server
     state: restarted
+  when: __mssql_is_booted | bool

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,6 +22,7 @@ galaxy_info:
         - "15.5"
   galaxy_tags:
     - centos
+    - containerbuild
     - database
     - el7
     - el8

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -384,6 +384,11 @@
       register: __mssql_conf_setup
       no_log: true
       changed_when: true
+      # in non-booted mode this tries to start the server, which fails; it
+      # still configures things before, so tolerate that
+      failed_when: >-
+        (__mssql_is_booted and __mssql_conf_setup.rc != 0) or
+        (not __mssql_is_booted and __mssql_conf_setup.rc not in [0, 1])
       until: >-
         "Initial setup of Microsoft SQL Server failed."
         not in __mssql_conf_setup.stdout and
@@ -447,27 +452,32 @@
 - name: Ensure that the tuned service is started and enabled
   service:
     name: tuned
-    state: started
+    state: "{{ 'started' if __mssql_is_booted else omit }}"
     enabled: true
   when: __mssql_tuned_supported | bool
 
 - name: Get the active Tuned profiles
-  command: tuned-adm active
-  changed_when: false
-  register: __mssql_tuned_active_profiles
+  slurp:
+    path: /etc/tuned/active_profile
+  register: __mssql_tuned_active_profiles_b64
+  when: __mssql_tuned_supported | bool
+
+- name: Decode the active Tuned profiles
+  set_fact:
+    __mssql_tuned_active_profiles: "{{ __mssql_tuned_active_profiles_b64.content | b64decode | trim }}"
   when: __mssql_tuned_supported | bool
 
 # adding the mssql profile to the end of the list ensures
 # that it overrides conflicting settings in other profiles
-- name: Add mssql to the list of Tuned profiles
+- name: Add mssql to the list of Tuned profiles on booted systems
   when:
+    - __mssql_is_booted | bool
     - __mssql_tuned_supported | bool
-    - '"mssql" not in __mssql_tuned_active_profiles.stdout'
+    - '"mssql" not in __mssql_tuned_active_profiles'
   block:
     - name: Attempt to add mssql to the list of Tuned profiles
       command: >-
-        tuned-adm profile {{ __mssql_tuned_active_profiles.stdout
-        | regex_replace('^Current active profile: ', '') }} mssql
+        tuned-adm profile {{ __mssql_tuned_active_profiles }} mssql
       register: __mssql_tuned_adm_profile
       changed_when: __mssql_tuned_adm_profile.stderr | length == 0
       failed_when: false
@@ -488,13 +498,28 @@
 
     - name: Add the fixed mssql profile to the list of Tuned profiles
       command: >-
-        tuned-adm profile {{ __mssql_tuned_active_profiles.stdout |
-        regex_replace('^Current active profile: ', '') }} mssql
+        tuned-adm profile {{ __mssql_tuned_active_profiles }} mssql
       when: >-
         "Cannot find profile 'throughput-performance'" in
         __mssql_tuned_adm_profile.stderr
       register: __mssql_tuned_adm_profile
       changed_when: __mssql_tuned_adm_profile.stderr | length == 0
+
+# Once the above hack gets dropped, this can become the primary method of
+# changing the profile; restart tuned.service on booted systems then
+- name: Add mssql to the list of Tuned profiles on non-booted systems
+  when:
+    - not __mssql_is_booted | bool
+    - __mssql_tuned_supported | bool
+    - '"mssql" not in __mssql_tuned_active_profiles'
+  block:
+    - name: Attempt to add mssql to the list of Tuned profiles
+      copy:
+        dest: /etc/tuned/active_profile
+        content: "{{ __mssql_tuned_active_profiles }} mssql"
+        owner: root
+        group: root
+        mode: "0644"
 
 - name: Configure the Microsoft SQL Server Tools repository
   yum_repository:
@@ -654,12 +679,15 @@
         "TCP Provider: Error code 0x2749" not in __mssql_password_query.stdout
         and
         "TCP Provider: Error code 0x2749" not in __mssql_password_query.stderr
+      when: __mssql_is_booted | bool
 
     - name: Ensure that the mssql-server service is stopped
       service:
         name: mssql-server
         state: stopped
-      when: __mssql_password_query is failed
+      when:
+        - __mssql_is_booted | bool
+        - __mssql_password_query is failed
       notify: Restart the mssql-server service
 
     - name: Gather package facts
@@ -674,7 +702,7 @@
           shell: >-
             MSSQL_SA_PASSWORD={{ mssql_password | quote }}
             {{ __mssql_conf_cli }} --noprompt set-sa-password
-          when: __mssql_password_query is failed
+          when: (not __mssql_is_booted) or (__mssql_password_query is failed)
           notify: Restart the mssql-server service
           register: __mssql_set_ha_password
           no_log: true
@@ -700,7 +728,9 @@
       else
       [mssql_pre_input_sql_file] }}"
   include_tasks: input_sql_files.yml
-  when: mssql_pre_input_sql_file != []
+  when:
+    - __mssql_is_booted | bool
+    - mssql_pre_input_sql_file != []
 
 # Input content as list even when provided as a string
 - name: Pre-input SQL script contents to SQL Server
@@ -711,7 +741,9 @@
       else
       [mssql_pre_input_sql_content] }}"
   include_tasks: input_sql_files.yml
-  when: mssql_pre_input_sql_content != []
+  when:
+    - __mssql_is_booted | bool
+    - mssql_pre_input_sql_content != []
 
 - name: Set a new edition for MSSQL
   when:
@@ -731,12 +763,15 @@
       register: __mssql_edition_matches
       changed_when: false
       check_mode: false
+      when: __mssql_is_booted | bool
 
     - name: Ensure that the mssql-server service is stopped
       service:
         name: mssql-server
         state: stopped
-      when: not __mssql_edition_matches.stdout | bool
+      when:
+        - __mssql_is_booted | bool
+        - not __mssql_edition_matches.stdout | bool
       notify: Restart the mssql-server service
 
     - name: Gather package facts
@@ -751,7 +786,7 @@
             MSSQL_PID: "{{ mssql_edition }}"
           register: __mssql_conf_set_edition
           changed_when: '"The new edition" in __mssql_conf_set_edition.stdout'
-          when: not __mssql_edition_matches.stdout | bool
+          when: not __mssql_is_booted or not __mssql_edition_matches.stdout | bool
           notify: Restart the mssql-server service
           no_log: true
       rescue:
@@ -1196,8 +1231,10 @@
             name: mssql-server
             state: restarted
           # noqa no-handler
-          when: (__mssql_conf_set is changed) or
-            (__mssql_server_ha_packages_install | d({}) is changed)
+          when:
+            - __mssql_is_booted | bool
+            - (__mssql_conf_set is changed) or
+              (__mssql_server_ha_packages_install | d({}) is changed)
 
         - name: Remove certificates
           when: mssql_ha_reset_cert | bool
@@ -1364,9 +1401,10 @@
             name: mssql-server
             state: restarted
           # noqa no-handler
-          when: (__mssql_conf_set is changed) or
-            (__mssql_server_ha_packages_install | d({}) is changed)
-          register: __mssql_replica_restarted
+          when:
+            - __mssql_is_booted | bool
+            - (__mssql_conf_set is changed) or
+              (__mssql_server_ha_packages_install | d({}) is changed)
 
         - name: Remove certificate from SQL Server
           vars:

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -16,3 +16,23 @@
   vars:
     __mssql_vars_file: "{{ role_path }}/vars/{{ item }}"
   when: __mssql_vars_file is file
+
+- name: Determine if system is booted with systemd
+  when: __mssql_is_booted is not defined
+  block:
+    - name: Run systemctl
+      # noqa command-instead-of-module
+      command: systemctl is-system-running
+      register: __is_system_running
+      changed_when: false
+      failed_when: false
+
+    - name: Require installed systemd
+      fail:
+        msg: "Error: This role requires systemd to be installed."
+      when: '"No such file or directory" in __is_system_running.msg | d("")'
+
+    - name: Set flag to indicate that systemd runtime operations are available
+      set_fact:
+        # see https://www.man7.org/linux/man-pages/man1/systemctl.1.html#:~:text=is-system-running%20output
+        __mssql_is_booted: "{{ __is_system_running.stdout != 'offline' }}"

--- a/tasks/verify_password.yml
+++ b/tasks/verify_password.yml
@@ -4,6 +4,7 @@
   service:
     name: mssql-server
     state: started
+  when: __mssql_is_booted | bool
 
 - name: Check if a custom tcpport setting exist
   command: grep '^tcpport = ' {{ __mssql_conf_path }}

--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -79,6 +79,7 @@
 - name: Stop the mssql-server service  # noqa command-instead-of-module
   shell: systemctl stop mssql-server || true
   changed_when: false
+  when: __mssql_is_booted | bool
 
 - name: Get SELinux policy modules
   command: semodule -l

--- a/tests/tasks/mssql-sever-increase-start-limit.yml
+++ b/tests/tasks/mssql-sever-increase-start-limit.yml
@@ -23,4 +23,6 @@
 - name: Reload service daemon
   systemd:  # noqa no-handler
     daemon_reload: true
-  when: __mssql_modify_limit is changed
+  when:
+    - __mssql_modify_limit is changed
+    - __mssql_is_booted | d(true)

--- a/tests/tasks/tests_idempotency.yml
+++ b/tests/tasks/tests_idempotency.yml
@@ -85,7 +85,9 @@
   include_tasks: verify_settings.yml
   vars:
     __verify_mssql_password: "p@55w0rD1"
-    __verify_mssql_edition: Standard
+    # package defaults to Evaluation, but the tests above change it to
+    # 'Standard' in the case where the server actually runs
+    __verify_mssql_edition: "{{ 'Standard' if __mssql_is_booted else 'Evaluation' }}"
     __verify_mssql_tcp_port: 1435
     __verify_mssql_ip_address: 127.0.0.1
     __verify_mssql_agent_is_enabled: false

--- a/tests/tasks/verify_settings.yml
+++ b/tests/tasks/verify_settings.yml
@@ -5,36 +5,36 @@
     __mssql_conf_path: /var/opt/mssql/mssql.conf
   when: __verify_mssql_edition is defined
   block:
-    - name: Check if the errorlog file exists and its location
+    # unhelpfully, this only works if the server is not already running; thus
+    # only use this on non-booted systems
+    - name: Get server version on non-booted systems
+      command: /opt/mssql/bin/sqlservr -v
+      changed_when: false
+      register: __mssql_version_cmd
+      # duh, -v normally exits with 255
+      failed_when: not __mssql_version_cmd.rc in [0, 255]
+      when: not __mssql_is_booted | bool
+
+    # on booted systems, check it from the error log instead
+    - name: Get server edition on booted systems
       shell: |
         set -euo pipefail
         errorlog="$(grep '^errorlogfile' {{ __mssql_conf_path }} \
         2>&1 | sed 's\errorlogfile : \\')" || :
         if [ -f "${errorlog}" ]; then
-          echo "${errorlog}"
-        elif [ -f /var/opt/mssql/log/errorlog ]; then
-          echo "/var/opt/mssql/log/errorlog"
+          cat "${errorlog}"
         else
-          echo ""
+          cat /var/opt/mssql/log/errorlog
         fi
       changed_when: false
-      register: __mssql_errorlog
+      register: __mssql_version_log
+      when: __mssql_is_booted | bool
 
-    - name: Check if the set edition matches the existing edition
-      shell: |
-        errorlog_edition="$(grep -oi '{{ __verify_mssql_edition }} edition' \
-        {{ __mssql_errorlog.stdout }})"
-        if [ -z "${errorlog_edition}" ]; then
-          echo false
-        else
-          echo true
-        fi
-      register: __mssql_edition_matches
-      changed_when: false
-
-    - name: Verify if the edition matches
+    - name: Verify that the edition matches
       assert:
-        that: __mssql_edition_matches.stdout | bool
+        that: "'{{ __verify_mssql_edition }} Edition' in __output.stdout"
+      vars:
+        __output: "{{ __mssql_version_log if __mssql_is_booted else __mssql_version_cmd }}"
 
 - name: Verify the setting {{ item.key }}
   with_dict:
@@ -91,6 +91,7 @@
         public: true
 
     - name: Wait for mssql-server to get ready
+      when: __mssql_is_booted | bool
       block:
         - name: Wait for mssql-server to prepare for client connections
           wait_for:
@@ -131,6 +132,7 @@
         "TCP Provider: Timeout error [258]" not in __mssql_test_psw_query.stderr
       retries: 5
       delay: 10
+      when: __mssql_is_booted | bool
 
     - name: Set the mssql_password variable to default null
       set_fact:

--- a/tests/tests_configure_ha_cluster_external.yml
+++ b/tests/tests_configure_ha_cluster_external.yml
@@ -14,6 +14,9 @@
 ---
 - name: Verify HA functionality with external clusters and templates
   hosts: all
+  tags:
+    # this test doesn't work in container builds
+    - tests::booted
   vars:
     __mssql_single_node_test: "{{ ansible_play_hosts_all | length == 1 }}"
     mssql_debug: true

--- a/tests/tests_input_sql_file_2022.yml
+++ b/tests/tests_input_sql_file_2022.yml
@@ -2,6 +2,9 @@
 ---
 - name: Ensure that the role can input sql files to MSSQL
   hosts: all
+  tags:
+    # this test doesn't work in container builds
+    - tests::booted
   vars:
     mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true

--- a/tests/tests_tcp_firewall_2022.yml
+++ b/tests/tests_tcp_firewall_2022.yml
@@ -2,6 +2,10 @@
 ---
 - name: Verify the use of the firewall role to configure SQL Server TCP ports
   hosts: all
+  tags:
+    # FIXME: firewall role does not currently work in container builds
+    # https://issues.redhat.com/browse/RHEL-88425
+    - tests::booted
   vars:
     mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true

--- a/tests/tests_tls_2022.yml
+++ b/tests/tests_tls_2022.yml
@@ -2,6 +2,9 @@
 ---
 - name: Ensure that tls encryption configuration works
   hosts: all
+  tags:
+    # certificate role can not work in container builds
+    - tests::booted
   vars:
     mssql_accept_microsoft_odbc_driver_for_sql_server_eula: true
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true


### PR DESCRIPTION
feat: Support this role in container builds

Feature: Support running the mssql role during container builds.

Reason: This is particularly useful for building bootc derivative OSes.

Result: These flags enable running the bootc container scenarios in CI,
which ensures that the role works in buildah build environment. This
allows us to officially support this role for image mode builds.

Fixes https://issues.redhat.com/browse/RHEL-89581

## Summary by Sourcery

Enable the mssql role to run reliably in container build environments by detecting systemd boot state and conditionally adjusting tasks, services, and tests to support non-booted scenarios.

New Features:
- Detect systemd boot status via a new __mssql_is_booted flag.
- Support executing role tasks in non-booted (container) environments.

Enhancements:
- Conditionally gate service starts, Tuned profile operations, SQL inputs, edition settings, and handlers based on booted state.
- Manage Tuned profiles in containers by directly updating /etc/tuned/active_profile instead of using tuned-adm.
- Relax initial configuration failure checks to tolerate container startup errors.

Documentation:
- Add a 'containerbuild' tag to galaxy metadata to document container support.

Tests:
- Separate edition and version verification logic for booted vs non-booted systems.
- Tag and skip booted-only tests when running in container builds.