### PR TITLE
tests: Add workaround for Ansible 2.9 SELinux cleanup failure

### DIFF
--- a/tests/tests_idempotency_2022.yml
+++ b/tests/tests_idempotency_2022.yml
@@ -8,7 +8,7 @@
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2022
-    mssql_manage_selinux: "{{ mssql_run_selinux_confined }}"
+    mssql_manage_selinux: "{{ mssql_run_selinux_confined | d(false) }}"
     __mssql_gather_facts_no_log: true
   tasks:
     - name: Run test in a block to clean up in always

--- a/tests/tests_input_sql_file_2022.yml
+++ b/tests/tests_input_sql_file_2022.yml
@@ -8,7 +8,7 @@
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_debug: true
     mssql_version: 2022
-    mssql_manage_selinux: "{{ mssql_run_selinux_confined }}"
+    mssql_manage_selinux: "{{ mssql_run_selinux_confined | d(false) }}"
     __mssql_gather_facts_no_log: true
   tasks:
     - name: Run test in a block to clean up in always

--- a/tests/tests_password_2022.yml
+++ b/tests/tests_password_2022.yml
@@ -7,7 +7,7 @@
     mssql_accept_microsoft_cli_utilities_for_sql_server_eula: true
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_version: 2022
-    mssql_manage_selinux: "{{ mssql_run_selinux_confined }}"
+    mssql_manage_selinux: "{{ mssql_run_selinux_confined | d(false) }}"
     __mssql_gather_facts_no_log: true
   tasks:
     - name: Run test in a block to clean up in always

--- a/tests/tests_tcp_firewall_2022.yml
+++ b/tests/tests_tcp_firewall_2022.yml
@@ -8,7 +8,7 @@
     mssql_accept_microsoft_sql_server_standard_eula: true
     mssql_manage_firewall: true
     mssql_version: 2022
-    mssql_manage_selinux: "{{ mssql_run_selinux_confined }}"
+    mssql_manage_selinux: "{{ mssql_run_selinux_confined | d(false) }}"
     __mssql_gather_facts_no_log: true
   tasks:
     - name: Run test in a block to clean up in always

--- a/tests/tests_tls_2022.yml
+++ b/tests/tests_tls_2022.yml
@@ -11,7 +11,7 @@
     mssql_tcp_port: 1433
     mssql_version: 2022
     mssql_tls_self_sign: true
-    mssql_manage_selinux: "{{ mssql_run_selinux_confined }}"
+    mssql_manage_selinux: "{{ mssql_run_selinux_confined | d(false) }}"
     __mssql_gather_facts_no_log: true
   tasks:
     - name: Run test in a block to clean up in always


### PR DESCRIPTION
The "conditionalize SELinux cleanup" hack in commit e1c8d1fdf973f that fixed a regression with different test order caused a regression itself: On older Ansible (observed on 2.9) it fails some tests with:

> The conditional check 'mssql_manage_selinux | d(false) | bool' failed.
> The error was: error while evaluating conditional
> (mssql_manage_selinux | d(false) | bool): {{ mssql_run_selinux_confined }}:
> 'mssql_run_selinux_confined' is undefined

So the `d()` default does not apply to the actual definition of the variable in these versions.

Avoid that by adding a default to ensure that the value isn't undefined.

----

See https://github.com/linux-system-roles/mssql/pull/349#issuecomment-2879454290 . Fixes [this failure](https://dl.fedoraproject.org/pub/alt/linuxsystemroles/logs/tf_mssql-349_CentOS-Stream-8-2.9_20250514-083148/artifacts/tests_input_sql_file_2022-ANSIBLE-2.9-test_playbooks_parallel-FAIL.log) in the CentOS 8 TF tests. We missed that as #349 did not run `[citest]`, sorry about that!

## Summary by Sourcery

Work around Ansible 2.9 SELinux cleanup regression by defaulting the selinux management variable in test playbooks.

Bug Fixes:
- Ensure mssql_manage_selinux is always defined by adding a default(false) fallback to mssql_run_selinux_confined in test variables.

Tests:
- Update all 2022 test playbooks (idempotency, input SQL file, password, TCP firewall, TLS) to apply the default(false) filter for mssql_manage_selinux.

## Summary by Sourcery

Provide a fallback default for the SELinux management variable in test playbooks to avoid undefined-variable errors on Ansible 2.9.

Bug Fixes:
- Ensure mssql_manage_selinux is always defined by using a default(false) filter on mssql_run_selinux_confined in test variables.

Tests:
- Update all 2022 test playbooks (idempotency, input SQL file, password, TCP firewall, TLS) to apply the default(false) fallback for mssql_manage_selinux.