### PR TITLE
test: set role vars needed for cleanup

### DIFF
--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -3,6 +3,12 @@
   package_facts:
   no_log: true
 
+- name: Set role variables needed for cleanup
+  include_role:
+    name: linux-system-roles.mssql
+    tasks_from: set_vars.yml
+    public: true
+
 - name: Purge cluster configuration
   vars:
     ha_cluster_cluster_present: false


### PR DESCRIPTION
Some of the role vars like __mssql_confined_supported are needed
during cleanup - ensure they are defined.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Ensure required SQL Server role variables are set before running the cleanup play

Bug Fixes:
- Load missing mssql role variables during cleanup by including the role’s set_vars.yml

Tests:
- Add include_role step in cleanup.yml to import variables needed for cleanup tasks