### PR TITLE
chore: Clean up __mssql_tuned_supported declaration

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -442,26 +442,26 @@
   package:
     name: tuned-profiles-mssql
     state: present
-  when: __mssql_tuned_supported | bool
+  when: __mssql_tuned_supported
 
 - name: Ensure that the tuned service is started and enabled
   service:
     name: tuned
     state: started
     enabled: true
-  when: __mssql_tuned_supported | bool
+  when: __mssql_tuned_supported
 
 - name: Get the active Tuned profiles
   command: tuned-adm active
   changed_when: false
   register: __mssql_tuned_active_profiles
-  when: __mssql_tuned_supported | bool
+  when: __mssql_tuned_supported
 
 # adding the mssql profile to the end of the list ensures
 # that it overrides conflicting settings in other profiles
 - name: Add mssql to the list of Tuned profiles
   when:
-    - __mssql_tuned_supported | bool
+    - __mssql_tuned_supported
     - '"mssql" not in __mssql_tuned_active_profiles.stdout'
   block:
     - name: Attempt to add mssql to the list of Tuned profiles

--- a/vars/Suse.yml
+++ b/vars/Suse.yml
@@ -8,4 +8,3 @@ __mssql_supported_versions:
   - 2019
   - 2022
 __mssql_confined_supported: false
-__mssql_tuned_supported: false

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -66,6 +66,9 @@ __mssql_ha_private_key_dest: /var/opt/mssql/data/{{ mssql_ha_cert_name }}.pvk
 __mssql_ad_kinit_user: >-
   {{ mssql_ad_kerberos_user }}@{{ ad_integration_realm | upper }}
 
+# OS has tuned with the extra "mssql" profile
+__mssql_tuned_supported: false
+
 # BEGIN - DO NOT EDIT THIS BLOCK - rh distros variables
 # Ansible distribution identifiers that the role treats like RHEL
 __mssql_rh_distros:


### PR DESCRIPTION
Stop using `| bool` as a way to squeeze a value out of an undefined variable. Instead, define a default in vars/main.yml.

There's no need to typecast it, it's (supposed to) always be a bool, and it's internal.

----

Spotted in https://github.com/linux-system-roles/mssql/pull/349/files#r2091064755 ff.

## Summary by Sourcery

Introduce a default declaration for __mssql_tuned_supported and clean up its usage in task conditionals by removing redundant type casting and duplicate definitions.

Enhancements:
- Simplify task conditionals by removing unnecessary '| bool' filters from __mssql_tuned_supported checks.

Chores:
- Define default __mssql_tuned_supported variable as false in vars/main.yml.
- Remove duplicate __mssql_tuned_supported declaration from vars/Suse.yml.