### PR TITLE
ci: Add mssql_ha plan

### DIFF
--- a/plans/mssql_ha.fmf
+++ b/plans/mssql_ha.fmf
@@ -1,0 +1,77 @@
+summary: A general test for a system role
+tag: mssql
+provision:
+  - name: control-node1
+    role: control_node
+  - name: managed-node1
+    role: managed_node
+    hardware:
+      memory: ">= 4096 MB"
+    # Provision all machines in the same AWS pool to ensure that they are in the same subnet
+    pool: aws-testing-farm-09
+  - name: managed-node2
+    role: managed_node
+    hardware:
+      memory: ">= 4096 MB"
+    pool: aws-testing-farm-09
+  - name: managed-node3
+    role: managed_node
+    hardware:
+      memory: ">= 4096 MB"
+    pool: aws-testing-farm-09
+  - name: virtualip-node1
+    role: virtualip
+    pool: aws-testing-farm-09
+environment:
+    SR_ANSIBLE_VER: 2.17
+    SR_PYTHON_VERSION: 3.12
+    SR_REPO_NAME: mssql
+    SR_ONLY_TESTS: "tests_configure_ha_cluster_external.yml tests_configure_ha_cluster_read_scale.yml"
+    SR_TEST_LOCAL_CHANGES: false
+    SR_PR_NUM: ""
+    SR_LSR_USER: ""
+    SR_LSR_DOMAIN: ""
+    SR_LSR_SSH_KEY: ""
+    SR_ARTIFACTS_DIR: ""
+    SR_ARTIFACTS_URL: ""
+    SR_TFT_DEBUG: false
+prepare:
+  - name: Use vault.centos.org repos (CS 7, 8 EOL workaround)
+    script: |
+      if grep -q 'CentOS Stream release 8' /etc/redhat-release; then
+        sed -i '/^mirror/d;s/#\(baseurl=http:\/\/\)mirror/\1vault/' /etc/yum.repos.d/*.repo
+      fi
+      if grep -q 'CentOS Linux release 7.9' /etc/redhat-release; then
+        sed -i '/^mirror/d;s/#\?\(baseurl=http:\/\/\)mirror/\1vault/' /etc/yum.repos.d/*.repo
+      fi
+  # Replace with feature: epel: enabled once https://github.com/teemtee/tmt/pull/3128 is merged
+  - name: Enable epel to install beakerlib
+    script: |
+      # CS 10 and Fedora doesn't require epel
+      if grep -q -e 'CentOS Stream release 10' -e 'Fedora release' /etc/redhat-release; then
+        exit 0
+      fi
+      yum install epel-release yum-utils -y
+      yum-config-manager --enable epel epel-debuginfo epel-source
+discover:
+  - name: Prepare managed nodes
+    how: fmf
+    where: managed_node
+    filter: tag:prep_managed_node
+    url: https://github.com/linux-system-roles/tft-tests
+    ref: main
+  - name: Run test playbooks from control_node
+    how: fmf
+    where: control_node
+    filter: tag:mssql_ha
+    url: https://github.com/linux-system-roles/tft-tests
+    ref: main
+  # Uncomment this step for troubleshooting
+  # This is required because currently testing-farm cli doesn't support running multi-node plans
+  # You can set ID_RSA_PUB in the environment section above to your public key to distribute it to nodes
+  # - name: Inject your ssh public key to test systems
+  #   how: fmf
+  #   where: control_node
+  #   filter: tag:reserve_system
+execute:
+    how: tmt


### PR DESCRIPTION
I forgot to move it when moved general plans to the roles

## Summary by Sourcery

CI:
- Add mssql_ha plan to the CI test plans directory.