### PR TITLE
tests: Update tests_password_2022 to do bootc end-to-end validation

### DIFF
--- a/tests/tasks/tests_password.yml
+++ b/tests/tasks/tests_password.yml
@@ -2,6 +2,12 @@
 - name: Assert fail on EL 7 with version = 2022 and EL 9 with version != 2022
   include_tasks: assert_fail_on_unsupported_ver.yml
 
+# role does not run during bootc QEMU validation, thus _is_booted is undefined
+- name: Set __mssql_is_booted for bootc validation tests
+  set_fact:
+    __mssql_is_booted: true
+  when: __bootc_validation | d(false)
+
 - name: Set up MSSQL
   include_role:
     name: linux-system-roles.mssql
@@ -9,9 +15,11 @@
     mssql_password: "p@55w0rD"
     mssql_edition: Evaluation
     mssql_tools_versions: [17]
+  when: not __bootc_validation | d(false)
 
 - name: Configure the mssql-server service start limit interval and burst
   include_tasks: tasks/mssql-sever-increase-start-limit.yml
+  when: not __bootc_validation | d(false)
 
 - name: >-
     Change the password with default settings.
@@ -20,11 +28,13 @@
     name: linux-system-roles.mssql
   vars:
     mssql_password: "p@55w0rD11"
+  when: not __bootc_validation | d(false)
 
 - name: Verify settings
   include_tasks: tasks/verify_settings.yml
   vars:
     __verify_mssql_password: "p@55w0rD11"
+  when: not __bootc_validation | d(false)
 
 - name: Verify the package {{ __mssql_verify_package_name }}
   include_tasks: verify_package.yml
@@ -37,6 +47,14 @@
     name: linux-system-roles.mssql
   vars:
     mssql_ip_address: 127.0.0.1
+  when: not __bootc_validation | d(false)
+
+- name: Create QEMU deployment during bootc end-to-end test
+  delegate_to: localhost
+  become: false
+  command: "{{ lsr_scriptdir }}/bootc-buildah-qcow.sh {{ ansible_host }}"
+  changed_when: true
+  when: ansible_connection == "buildah"
 
 - name: >-
     Change the password with a custom IP address.
@@ -46,11 +64,13 @@
   vars:
     mssql_password: "p@55w0rD"
     mssql_tools_versions: [17, 18]
+  when: not __bootc_validation | d(false)
 
 - name: Verify settings
   include_tasks: tasks/verify_settings.yml
   vars:
     __verify_mssql_password: "p@55w0rD"
+  when: not __bootc_validation | d(false)
 
 - name: Verify the package {{ __mssql_verify_package_name }}
   include_tasks: verify_package.yml
@@ -63,6 +83,7 @@
     name: linux-system-roles.mssql
   vars:
     mssql_tcp_port: 1432
+  when: not __bootc_validation | d(false)
 
 - name: >-
     Change the password with a custom TCP port and IP address.
@@ -72,11 +93,13 @@
   vars:
     mssql_password: "p@55w0rD11"
     mssql_tools_versions: [18]
+  when: not __bootc_validation | d(false)
 
 - name: Verify settings
   include_tasks: tasks/verify_settings.yml
   vars:
     __verify_mssql_password: "p@55w0rD11"
+  when: not __bootc_validation | d(false)
 
 - name: Verify the package {{ __mssql_verify_package_name }}
   include_tasks: verify_package.yml

--- a/tests/tests_password_2022.yml
+++ b/tests/tests_password_2022.yml
@@ -17,3 +17,4 @@
       always:
         - name: Clean up after the role invocation
           include_tasks: tasks/cleanup.yml
+          when: not __bootc_validation | d(false)


### PR DESCRIPTION
This only covers the initial role invocation. The others which change passwords and ports are skipped during the validation run. In principle it would be interesting to run them on the deployed QEMU side, but in practice that currently fails with

> Configure to run as a confined application with SELinux
> tests/roles/linux-system-roles.mssql/tasks/main.yml:312
> missing required arguments: backend, image

due to the partial invocation and hence missing global variables. So let's defer that until we do a concerted effort of running the roles on bootc deployments.

See https://issues.redhat.com/browse/RHEL-78157

Enhancement:

Reason:

Result:

Issue Tracker Tickets (Jira or BZ if any):
