### PR TITLE
ci: Add a new playbook to mssql_ha test plan

### DIFF
--- a/plans/mssql_ha.fmf
+++ b/plans/mssql_ha.fmf
@@ -26,7 +26,7 @@ environment:
     SR_ANSIBLE_VER: 2.17
     SR_PYTHON_VERSION: 3.12
     SR_REPO_NAME: mssql
-    SR_ONLY_TESTS: "tests_configure_ha_cluster_external.yml tests_configure_ha_cluster_read_scale.yml"
+    SR_ONLY_TESTS: "tests_configure_ha_cluster_external.yml tests_configure_ha_cluster_read_scale.yml tests_configure_ha_cluster_external_read_only.yml"
     SR_TEST_LOCAL_CHANGES: false
     SR_PR_NUM: ""
     SR_LSR_USER: ""


### PR DESCRIPTION
Enhancement: Add a new playbook to mssql_ha test plan

Reason: Sync with #338, https://github.com/linux-system-roles/tft-tests/pull/83

## Summary by Sourcery

Tests:
- Include a new playbook in the mssql_ha test plan