### PR TITLE
fix: Retry set up and sqlcms until success instead of conditions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -425,11 +425,7 @@
       failed_when: >-
         (__mssql_is_booted and __mssql_conf_setup.rc != 0) or
         (not __mssql_is_booted and __mssql_conf_setup.rc not in [0, 1])
-      until: >-
-        "Initial setup of Microsoft SQL Server failed."
-        not in __mssql_conf_setup.stdout and
-        "Initial setup of Microsoft SQL Server failed."
-        not in __mssql_conf_setup.stderr
+      until: __mssql_conf_setup is success
   rescue:
     - name: Print output of failed task
       when: item | length > 0
@@ -707,14 +703,7 @@
       changed_when: false
       register: __mssql_password_query
       no_log: true
-      until: >-
-        "TCP Provider: Error code 0x102" not in __mssql_password_query.stdout
-        and
-        "TCP Provider: Error code 0x102" not in __mssql_password_query.stderr
-        and
-        "TCP Provider: Error code 0x2749" not in __mssql_password_query.stdout
-        and
-        "TCP Provider: Error code 0x2749" not in __mssql_password_query.stderr
+      until: __mssql_password_query is success
       when: __mssql_is_booted | bool
 
     - name: Ensure that the mssql-server service is stopped

--- a/tasks/sqlcmd_input_content.yml
+++ b/tasks/sqlcmd_input_content.yml
@@ -7,11 +7,7 @@
       register: __mssql_sqlcmd_input
       changed_when: '"successfully" in __mssql_sqlcmd_input.stdout'
       no_log: true
-      until: >-
-        "TCP Provider: Error code 0x102" not in __mssql_sqlcmd_input.stdout and
-        "TCP Provider: Error code 0x102" not in __mssql_sqlcmd_input.stderr and
-        "TCP Provider: Error code 0x2749" not in __mssql_sqlcmd_input.stdout and
-        "TCP Provider: Error code 0x2749" not in __mssql_sqlcmd_input.stderr
+      until: __mssql_sqlcmd_input is success
 
   always:
     # Role prints the output if the input succeeds, otherwise Ansible prints the

--- a/tasks/sqlcmd_input_file.yml
+++ b/tasks/sqlcmd_input_file.yml
@@ -31,13 +31,7 @@
       register: __mssql_sqlcmd_input
       changed_when: '"successfully" in __mssql_sqlcmd_input.stdout'
       no_log: true
-      until: >-
-        "TCP Provider: Error code 0x68" not in __mssql_sqlcmd_input.stdout and
-        "TCP Provider: Error code 0x68" not in __mssql_sqlcmd_input.stderr and
-        "TCP Provider: Error code 0x102" not in __mssql_sqlcmd_input.stdout and
-        "TCP Provider: Error code 0x102" not in __mssql_sqlcmd_input.stderr and
-        "TCP Provider: Error code 0x2749" not in __mssql_sqlcmd_input.stdout and
-        "TCP Provider: Error code 0x2749" not in __mssql_sqlcmd_input.stderr
+      until: __mssql_sqlcmd_input is success
   always:
     # Role prints the output if the input succeeds, otherwise Ansible prints the
     # output from the failed input tasks


### PR DESCRIPTION
Enhancement: Retry setting up SQL Server and calling sqlcmd

Reason: Sometimes SQL Server is unstable and requires several attempts to connect properly. Currently, this happens when trying to set up SQL Server on EL 9 with SELinux in enforcing state.

Result: Attempts success after a couple retries.
