### PR TITLE
refactor: support ansible 2.19

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -587,19 +587,26 @@
         - mssql_tls_enable | bool
         - mssql_tls_certificates | length > 0
       block:
+        - name: Reset certificate_requests
+          set_fact:
+            __mssql_certificate_requests: []
+
+        - name: Set certificate_requests
+          set_fact:
+            __mssql_certificate_requests: "{{ __mssql_certificate_requests + [item | combine(__cert_item)] }}"
+          loop: "{{ mssql_tls_certificates }}"
+          vars:
+            __cert_item:
+              name: "{{ item.name | basename }}"
+              owner: mssql
+              group: mssql
+              mode: "0600"
+
         - name: Create certificates using the certificate role
           include_role:
             name: fedora.linux_system_roles.certificate
           vars:
-            certificate_requests: |
-              {% for _cert in mssql_tls_certificates %}
-              {%   set _basename = _cert.name | basename %}
-              {%   set _ = _cert.__setitem__('name', _basename) %}
-              {%   set _ = _cert.__setitem__('owner', 'mssql') %}
-              {%   set _ = _cert.__setitem__('group', 'mssql') %}
-              {%   set _ = _cert.__setitem__('mode', '0600') %}
-              {% endfor %}
-              {{ mssql_tls_certificates }}
+            certificate_requests: "{{ __mssql_certificate_requests }}"
 
         - name: Set mssql_tls_cert and _private_key based on the cert name
           set_fact:
@@ -1326,25 +1333,15 @@
 
         - name: Set fact with the current primary replica
           set_fact:
-            __mssql_ha_is_primary: |-
-              {% set hadr_curr_primary = [] %}
-              {% for item in ansible_play_hosts %}
-              {%   if hostvars[item]['__mssql_sqlcmd_input']['stdout']
-                   | int == 1 %}
-              {{ hadr_curr_primary.append(item) -}}
-              {%   endif %}
-              {% endfor %}
-              {%- if hadr_curr_primary | length > 0
-                and
-                hadr_curr_primary[0] == inventory_hostname %}
-              true
-              {%- elif hadr_curr_primary | length == 0
-                and
-                mssql_ha_replica_type == 'primary' %}
-              true
-              {%- else %}
-              false
-              {%- endif %}
+            __mssql_ha_is_primary: "{{ (
+                hadr_curr_primary | length > 0 and
+                inventory_hostname in hadr_curr_primary
+              ) or (
+                hadr_curr_primary | length == 0 and
+                mssql_ha_replica_type == 'primary') }}"
+          vars:
+            hadr_curr_primary: "{{ hostvars | dict2items | selectattr('key', 'in', ansible_play_hosts) |
+              selectattr('value.__mssql_sqlcmd_input.stdout', 'match', '^1$') | map(attribute='key') | list }}"
 
         - name: Verify that primary instance hosts is available
           assert:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -15,7 +15,7 @@ __mssql_server_selinux_packages: mssql-server-selinux
 __sqlcmd_ver: "{{ mssql_tools_versions | sort | last }}"
 __sqlcmd_cli: "{{
   '/opt/mssql-tools/bin/sqlcmd' if __sqlcmd_ver == '17'
-  else '/opt/mssql-tools' + __sqlcmd_ver + '/bin/sqlcmd' }}"
+  else '/opt/mssql-tools' + (__sqlcmd_ver | string) + '/bin/sqlcmd' }}"
 __mssql_client_packages:
   - mssql-tools{{ '' if __sqlcmd_ver == '17' else __sqlcmd_ver }}
   - unixODBC-devel


### PR DESCRIPTION
Ansible 2.19 introduces some big changes
https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_core_2.19.html

One big change is that data structures are no longer mutable by the use of python
methods such as `__setitem__`, `setdefault`, `update`, etc.  in Jinja constructs.
Instead, items must use filters or other Jinja operations.

One common idiom is to mutate each element in a list.  Since we cannot do this
"in-place" anymore, a common way to do this is:

```yaml
- name: Construct a new list from an existing list and mutate each element
  set_fact:
    __new_list: "{{ __new_list | d([]) + [mutated_item] }}"
  loop: "{{ old_list }}"
  mutated_item: "{{ some value based on item from old list }}"

- name: Reset original old list
  set_fact:
    old_list: "{{ __new_list }}"
```

Similarly with `dict` items:

```yaml
- name: Construct a new dict from an existing dict and mutate each element
  set_fact:
    __new_dict: "{{ __new_dict | d({}) | combine(mutated_item) }}"
  loop: "{{ old_dict | dict2items }}"
  mutated_item: "{{ {item.key: mutation of item.value} }}"

- name: Reset original old dict
  set_fact:
    old_dict: "{{ __new_dict }}"
```

Another big change is that a boolean expression in a `when` or similar construct
must be converted to a boolean - we cannot rely on the implicit evaluation in
a boolean context.  For example, if `var` is some iterable, like a `dict`, `list`,
or `string`, you used to be able to evaluate an empty value in a boolean context:

```yaml
when: var  # do this only if var is not empty
```

You now have to explicitly test for empty using `length`:

```yaml
when: var | length > 0  # do this only if var is not empty
```

These are the biggest changes.  See the porting guide for others.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Refactor Jinja templates and set_fact usage to comply with Ansible 2.19’s immutability rules by replacing in-place data mutations and complex Jinja control flow with filter-based expressions and accumulation patterns.

Enhancements:
- Accumulate certificate_requests list via sequential set_fact calls instead of mutating original list in Jinja.
- Replace multi-line Jinja logic for __mssql_ha_is_primary with a concise expression using dict2items, selectattr, map, and boolean filters.
- Ensure __sqlcmd_cli path is constructed with explicit string conversion of __sqlcmd_ver to prevent type mismatches.