### PR TITLE
test: verify that tests_ha_single fails on EL7 in the beginning

### DIFF
--- a/templates/configure_ag.j2
+++ b/templates/configure_ag.j2
@@ -73,16 +73,16 @@ BEGIN
 {# In the first loop, add primaries at the end and witness at the beginning #}
 {% for item in ansible_play_hosts_all %}
 {%   if hostvars[item]['mssql_ha_replica_type'] == 'primary' %}
-{{ ag_replicas_primary_last.append(item) -}}
+{%     set _ = ag_replicas_primary_last.append(item) %}
 {%   elif hostvars[item]['mssql_ha_replica_type'] == 'witness' %}
-{{ ag_replicas_primary_last.insert(0, item) -}}
+{%     set _ = ag_replicas_primary_last.insert(0, item) %}
 {%   endif %}
 {% endfor %}
 {# In the second loop, add others at the beginning #}
 {% for item in ansible_play_hosts_all %}
 {%   if hostvars[item]['mssql_ha_replica_type']
      not in ag_replicas_primary_last %}
-{{ ag_replicas_primary_last.insert(0, item) -}}
+{%     set _ = ag_replicas_primary_last.insert(0, item) %}
 {%   endif %}
 {% endfor %}
 {% for item in ag_replicas_primary_last %}
@@ -337,13 +337,13 @@ restore to reuse it for the newly created AG {{ mssql_ha_ag_name }}';
 {# In the first loop, add not primaries to a new list #}
 {% for item in ansible_play_hosts_all %}
 {%   if hostvars[item]['mssql_ha_replica_type'] != 'primary' %}
-{{ ag_replicas_primary_first.append(item) -}}
+{%     set _ = ag_replicas_primary_first.append(item) %}
 {%   endif %}
 {% endfor %}
 {# In the second loop, add primary at the beginning #}
 {% for item in ansible_play_hosts_all %}
 {%   if hostvars[item]['mssql_ha_replica_type'] == 'primary' %}
-{{ ag_replicas_primary_first.insert(0, item) -}}
+{%     set _ = ag_replicas_primary_first.insert(0, item) %}
 {%   endif %}
 {% endfor %}
 {% for item in ag_replicas_primary_first %}

--- a/tests/tasks/assert_fail_on_unsupported_ver.yml
+++ b/tests/tasks/assert_fail_on_unsupported_ver.yml
@@ -29,6 +29,9 @@
         that: >-
           'You must set the mssql_version variable to one of'
           in ansible_failed_result.msg
+          or
+          'mssql_ha_configure=true does not support running against EL 7 hosts'
+          in ansible_failed_result.msg
 
     - name: Clean up after the role invocation
       include_tasks: tasks/cleanup.yml

--- a/tests/tasks/tests_ha_single.yml
+++ b/tests/tasks/tests_ha_single.yml
@@ -1,30 +1,5 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Verify that the role fails when primary node is not specified
-  when: ansible_play_hosts_all | length == 1
-  block:
-    - name: Run role with mssql_replica_type=primary not defined
-      include_role:
-        name: linux-system-roles.mssql
-
-    - name: Unreachable task
-      fail:
-        msg: The above task must fail
-  rescue:
-    - name: Assert that the role fails when primary node is not specified
-      assert:
-        that: >-
-          'You must set the mssql_ha_replica_type variable to one of
-          primary, synchronous, asynchronous, witness, absent'
-          in ansible_failed_result.msg
-
-- name: Set the mssql_ha_replica_type fact to appear in hostvars
-  set_fact:
-    mssql_ha_replica_type: primary
-
-- name: Assert fail on EL 7 with version = 2022 and EL 9 with version != 2022
-  include_tasks: assert_fail_on_unsupported_ver.yml
-
 - name: Verify that by default the role fails on EL < 8
   when:
     - ansible_distribution in ['CentOS', 'RedHat']
@@ -53,6 +28,31 @@
     # Putting end_host into a rescue block results in a failed task
     - name: End EL 7 host
       meta: end_host
+
+- name: Verify that the role fails when primary node is not specified
+  when: ansible_play_hosts_all | length == 1
+  block:
+    - name: Run role with mssql_replica_type=primary not defined
+      include_role:
+        name: linux-system-roles.mssql
+
+    - name: Unreachable task
+      fail:
+        msg: The above task must fail
+  rescue:
+    - name: Assert that the role fails when primary node is not specified
+      assert:
+        that: >-
+          'You must set the mssql_ha_replica_type variable to one of
+          primary, synchronous, asynchronous, witness, absent'
+          in ansible_failed_result.msg
+
+- name: Set the mssql_ha_replica_type fact to appear in hostvars
+  set_fact:
+    mssql_ha_replica_type: primary
+
+- name: Assert fail on EL 7 with version = 2022 and EL 9 with version != 2022
+  include_tasks: assert_fail_on_unsupported_ver.yml
 
 - name: Verify fail when ag_is_contained=false,reuse_system_db=true
   block:

--- a/tests/tests_configure_ha_cluster_external.yml
+++ b/tests/tests_configure_ha_cluster_external.yml
@@ -111,6 +111,9 @@
           meta: end_play
           when: ansible_play_hosts_all | length < 3
 
+        - name: Assert fail on EL 7 with version = 2022 and EL 9 with version != 2022
+          include_tasks: tasks/assert_fail_on_unsupported_ver.yml
+
         - name: Load softdog module for stonith to have at least one watchdog
           command: modprobe softdog
           changed_when: true

--- a/tests/tests_configure_ha_cluster_external_read_only.yml
+++ b/tests/tests_configure_ha_cluster_external_read_only.yml
@@ -114,6 +114,9 @@
           meta: end_play
           when: ansible_play_hosts_all | length < 3
 
+        - name: Assert fail on EL 7 with version = 2022 and EL 9 with version != 2022
+          include_tasks: tasks/assert_fail_on_unsupported_ver.yml
+
         - name: Load softdog module for stonith to have at least one watchdog
           command: modprobe softdog
           changed_when: true

--- a/tests/tests_configure_ha_cluster_read_scale.yml
+++ b/tests/tests_configure_ha_cluster_read_scale.yml
@@ -46,6 +46,9 @@
           meta: end_play
           when: ansible_play_hosts_all | length < 3
 
+        - name: Assert fail on EL 7 with version = 2022 and EL 9 with version != 2022
+          include_tasks: tasks/assert_fail_on_unsupported_ver.yml
+
         - name: Clusters of a read_scale type must not have a witness node
           meta: end_play
           when: ansible_play_hosts_all |

--- a/tests/tests_ha_single_2017.yml
+++ b/tests/tests_ha_single_2017.yml
@@ -7,6 +7,10 @@
 ---
 - name: Verify HA functionality with a single-node test
   hosts: all
+  tags:
+    # modprobe softdog doesn't work in containers because softdog is not in the
+    # container image
+    - tests::booted
   gather_facts: true
   vars:
     __mssql_single_node_test: "{{ ansible_play_hosts_all | length == 1 }}"

--- a/tests/tests_ha_single_2019.yml
+++ b/tests/tests_ha_single_2019.yml
@@ -7,6 +7,10 @@
 ---
 - name: Verify HA functionality with a single-node test
   hosts: all
+  tags:
+    # modprobe softdog doesn't work in containers because softdog is not in the
+    # container image
+    - tests::booted
   gather_facts: true
   vars:
     __mssql_single_node_test: "{{ ansible_play_hosts_all | length == 1 }}"

--- a/tests/tests_ha_single_2022.yml
+++ b/tests/tests_ha_single_2022.yml
@@ -7,6 +7,10 @@
 ---
 - name: Verify HA functionality with a single-node test
   hosts: all
+  tags:
+    # modprobe softdog doesn't work in containers because softdog is not in the
+    # container image
+    - tests::booted
   gather_facts: true
   vars:
     __mssql_single_node_test: "{{ ansible_play_hosts_all | length == 1 }}"

--- a/tests/tests_selinux_enforcing_2022.yml
+++ b/tests/tests_selinux_enforcing_2022.yml
@@ -58,6 +58,12 @@
         - name: Configure the mssql-server service start limit interval and burst
           include_tasks: tasks/mssql-sever-increase-start-limit.yml
 
+        - name: Set SELinux to permissive to test without selinux_confined
+          include_role:
+            name: fedora.linux_system_roles.selinux
+          vars:
+            selinux_state: permissive
+
         - name: Run without selinux_confined
           include_role:
             name: linux-system-roles.mssql

--- a/vars/Suse.yml
+++ b/vars/Suse.yml
@@ -3,7 +3,7 @@
 __mssql_base_repository: "https://packages.microsoft.com/sles/{{ ansible_facts['distribution_major_version'] | int }}/"
 __mssql_server_repository: "{{ __mssql_base_repository }}mssql-server-{{ mssql_version | int }}/"
 __mssql_client_repository: "{{ __mssql_base_repository }}prod/"
-__mssql_client_packages: "mssql-tools{{ '' if __sqlcmd_ver == '17' else __sqlcmd_ver }}"
+__mssql_client_packages: "mssql-tools{{ '' if __sqlcmd_ver | int == 17 else __sqlcmd_ver }}"
 __mssql_supported_versions:
   - 2019
   - 2022

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -14,10 +14,10 @@ __mssql_server_packages: mssql-server
 __mssql_server_selinux_packages: mssql-server-selinux
 __sqlcmd_ver: "{{ mssql_tools_versions | sort | last }}"
 __sqlcmd_cli: "{{
-  '/opt/mssql-tools/bin/sqlcmd' if __sqlcmd_ver == '17'
+  '/opt/mssql-tools/bin/sqlcmd' if __sqlcmd_ver | int == 17
   else '/opt/mssql-tools' + (__sqlcmd_ver | string) + '/bin/sqlcmd' }}"
 __mssql_client_packages:
-  - mssql-tools{{ '' if __sqlcmd_ver == '17' else __sqlcmd_ver }}
+  - mssql-tools{{ '' if __sqlcmd_ver | int == 17 else __sqlcmd_ver }}
   - unixODBC-devel
 __mssql_server_fts_packages: mssql-server-fts
 __mssql_server_ha_packages: mssql-server-ha


### PR DESCRIPTION
Enhancement: verify that tests_ha_single fails on EL7 in the beginning

## Summary by Sourcery

Reorder and consolidate single-node HA role tests to improve test flow and placement of primary replica and unsupported version failure checks.

Enhancements:
- Move the test verifying failure when mssql_ha_replica_type is not set to after the default EL <8 failure check
- Relocate the tasks for setting mssql_ha_replica_type fact and asserting unsupported EL7/EL9 version failures to follow the primary-node requirement test