### PR TITLE
docs(changelog): version 2.6.4 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+[2.6.4] - 2025-08-13
+--------------------
+
+### Other Changes
+
+- test: use post quantum crypto for certs where available (#368)
+- fix: Fix templates/configure_ag.j2 for Ansible 2.19
+
 [2.6.3] - 2025-07-25
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 2.6.4

Signed-off-by: Sergei Petrosian <spetrosi@redhat.com>

## Summary by Sourcery

Update project documentation for the 2.6.4 release and record new test changes in the changelog

Documentation:
- Bump version to 2.6.4 in CHANGELOG.md and .README.html

Tests:
- Use post quantum crypto for certs where available in tests (#368)
- Verify that tests_ha_single fails on EL7 in the beginning (#369)