### PR TITLE
ci: use JSON format for __bootc_validation

### DIFF
--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -201,7 +201,7 @@ jobs:
               if tox -e "$env" -- --image-file "$(pwd)/$image_file" \
                      --log-level debug $TOX_ARGS \
                      --lsr-report-errors-url DEFAULT \
-                     -e "__bootc_validation: true" \
+                     -e '{"__bootc_validation": true}' \
                      -- "$test" >out 2>&1; then
                   mv out "${test}-PASS.log"
               else


### PR DESCRIPTION
On some versions of ansible/jinja, the YAML format does not work, so use
the JSON format to pass in __bootc_validation

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Use JSON format for the __bootc_validation extra variable in the QEMU-KVM integration tests workflow to avoid YAML parsing issues with certain Ansible/Jinja versions.

Bug Fixes:
- Address failures in passing __bootc_validation due to YAML format incompatibility with some Ansible/Jinja releases

CI:
- Switch the __bootc_validation flag to JSON format in .github/workflows/qemu-kvm-integration-tests.yml