### PR TITLE
ci: Update AWS pool name

### DIFF
--- a/plans/mssql_ha.fmf
+++ b/plans/mssql_ha.fmf
@@ -8,20 +8,20 @@ provision:
     hardware:
       memory: ">= 4096 MB"
     # Provision all machines in the same AWS pool to ensure that they are in the same subnet
-    pool: aws-09-x86_64
+    pool: aws-09
   - name: managed-node2
     role: managed_node
     hardware:
       memory: ">= 4096 MB"
-    pool: aws-09-x86_64
+    pool: aws-09
   - name: managed-node3
     role: managed_node
     hardware:
       memory: ">= 4096 MB"
-    pool: aws-09-x86_64
+    pool: aws-09
   - name: virtualip-node1
     role: virtualip
-    pool: aws-09-x86_64
+    pool: aws-09
 environment:
     SR_ANSIBLE_VER: 2.17
     SR_PYTHON_VERSION: 3.12


### PR DESCRIPTION
Enhancement: Update AWS pool name

Reason: Testing Farm changes AWS pool name

Result: mssql_ha test plans runs smoothly

Issue Tracker Tickets (Jira or BZ if any):

## Summary by Sourcery

Enhancements:
- Adjust AWS pool name used by the mssql_ha test plan to match the updated Testing Farm pool naming.