### PR TITLE
feat: add Ubuntu 22.04 and 24.04 support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -20,6 +20,10 @@ galaxy_info:
     - name: opensuse
       versions:
         - "15.5"
+    - name: Ubuntu
+      versions:
+        - "22.04"
+        - "24.04"
   galaxy_tags:
     - centos
     - containerbuild

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -283,16 +283,27 @@
         url: "{{ mssql_rpm_key }}"
         dest: /tmp/microsoft.asc
         mode: '0644'
+<<<<<<< HEAD
       register: __mssql_gpg
       until: __mssql_gpg is success
       retries: 3
       delay: 5
+=======
+      register: __mssql_gpg_download
+      until: __mssql_gpg_download is success
+>>>>>>> c501f4b (fix ubuntu24 repo)
 
     - name: Convert Microsoft GPG key to binary keyring format
       command: >-
         gpg --dearmor -o {{ __mssql_gpg_key_dest }} /tmp/microsoft.asc
-      args:
-        creates: "{{ __mssql_gpg_key_dest }}"
+      changed_when: __mssql_gpg_download is changed
+
+    - name: Ensure correct permissions on Microsoft GPG keyring
+      file:
+        path: "{{ __mssql_gpg_key_dest }}"
+        owner: root
+        group: root
+        mode: '0644'
 
 - name: Prepare for the upgrade on RedHat
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -93,6 +93,24 @@
     - ansible_facts["distribution"] in ['CentOS', 'RedHat']
     - ansible_facts["distribution_major_version"] is version('10', '=')
 
+- name: Fail on Ubuntu when mssql_ha_configure is requested because it is not supported
+  fail:
+    msg: >-
+      This role does not support mssql_ha_configure on Ubuntu. HA configuration
+      is only supported on RHEL, CentOS, Fedora, and SLES platforms.
+  when:
+    - mssql_ha_configure | bool
+    - ansible_facts["distribution"] == 'Ubuntu'
+
+- name: Fail on Ubuntu when mssql_ad_configure is requested because it is not supported
+  fail:
+    msg: >-
+      This role does not support mssql_ad_configure on Ubuntu. AD configuration
+      is only supported on RHEL platforms.
+  when:
+    - mssql_ad_configure | bool
+    - ansible_facts["distribution"] == 'Ubuntu'
+
 - name: Verify that the user accepts EULA variables
   assert:
     that:
@@ -249,6 +267,30 @@
     state: present
   register: __mssql_gpg
   until: __mssql_gpg is success
+  when: ansible_facts["pkg_mgr"] != 'apt'
+
+- name: Deploy the GPG key for Microsoft repositories on Ubuntu
+  when: ansible_facts["pkg_mgr"] == 'apt'
+  block:
+    - name: Ensure gnupg is installed for key conversion
+      apt:
+        name: gnupg
+        state: present
+        update_cache: true
+
+    - name: Download Microsoft GPG key
+      get_url:
+        url: "{{ mssql_rpm_key }}"
+        dest: /tmp/microsoft.asc
+        mode: '0644'
+      register: __mssql_gpg
+      until: __mssql_gpg is success
+
+    - name: Convert Microsoft GPG key to binary keyring format
+      command: >-
+        gpg --dearmor -o {{ __mssql_gpg_key_dest }} /tmp/microsoft.asc
+      args:
+        creates: "{{ __mssql_gpg_key_dest }}"
 
 - name: Prepare for the upgrade on RedHat
   when:
@@ -344,6 +386,52 @@
   register: __zypper_addrepo_server_output
   failed_when: not __zypper_addrepo_server_output.rc in [0, 4]
   changed_when: __zypper_addrepo_server_output.rc != 4
+
+- name: Prepare for the upgrade on Ubuntu
+  when:
+    - __mssql_current_version is defined
+    - mssql_upgrade | bool
+    - ansible_facts["pkg_mgr"] == 'apt'
+    - __mssql_server_repository_list_url is defined
+    - __mssql_current_version | int != mssql_version | int
+  file:
+    path: /etc/apt/sources.list.d/mssql-server-{{ __mssql_current_version | int }}.list
+    state: absent
+
+- name: Configure the Microsoft SQL Server repo on Ubuntu using packages-microsoft-prod.deb
+  when:
+    - ansible_facts["pkg_mgr"] == 'apt'
+    - __mssql_prod_pkg_url is defined
+    - >-
+      (__mssql_server_packages not in ansible_facts.packages) or
+      (mssql_upgrade | bool)
+  block:
+    - name: Download packages-microsoft-prod.deb
+      get_url:
+        url: "{{ __mssql_prod_pkg_url }}"
+        dest: /tmp/packages-microsoft-prod.deb
+        mode: '0644'
+
+    - name: Install packages-microsoft-prod.deb
+      apt:
+        deb: /tmp/packages-microsoft-prod.deb
+
+- name: Configure the Microsoft SQL Server repo on Ubuntu 22 using list file
+  get_url:
+    url: "{{ __mssql_server_repository_list_url }}"
+    dest: /etc/apt/sources.list.d/mssql-server-{{ mssql_version | int }}.list
+    mode: '0644'
+  when:
+    - ansible_facts["pkg_mgr"] == 'apt'
+    - __mssql_server_repository_list_url is defined
+    - >-
+      (__mssql_server_packages not in ansible_facts.packages) or
+      (mssql_upgrade | bool)
+
+- name: Update apt cache after configuring Microsoft SQL Server repository
+  apt:
+    update_cache: true
+  when: ansible_facts["pkg_mgr"] == 'apt'
 
 - name: Configure to run as a confined application with SELinux
   package:
@@ -570,6 +658,20 @@
   failed_when: not __zypper_addrepo_tools_output.rc in [0, 4]
   changed_when: __zypper_addrepo_tools_output.rc != 4
 
+- name: Configure the Microsoft SQL Server Tools repository on Ubuntu 22 using list file
+  get_url:
+    url: "{{ __mssql_client_repository_list_url }}"
+    dest: /etc/apt/sources.list.d/mssql-release.list
+    mode: '0644'
+  when:
+    - ansible_facts["pkg_mgr"] == 'apt'
+    - __mssql_client_repository_list_url is defined
+
+- name: Update apt cache after configuring Microsoft SQL Server Tools repository
+  apt:
+    update_cache: true
+  when: ansible_facts["pkg_mgr"] == 'apt'
+
 - name: Ensure that SQL Server client tools are installed
   package:
     name: "{{ __mssql_client_packages }}"
@@ -580,6 +682,17 @@
 - name: Configure TLS encryption
   when: mssql_tls_enable is not none
   block:
+    - name: Ensure TLS private key directory exists on Debian-family systems
+      file:
+        path: "{{ __mssql_tls_private_key_dest_dir }}"
+        state: directory
+        owner: mssql
+        group: mssql
+        mode: "0700"
+      when:
+        - mssql_tls_enable | bool
+        - ansible_facts["pkg_mgr"] == 'apt'
+
     - name: >-
         Create certificate and private_key files and set mssql_tls_cert
         and _private_key
@@ -621,8 +734,8 @@
         src: "{{ item }}"
         remote_src: "{{ mssql_tls_remote_src }}"
         dest: >-
-          /etc/pki/tls/{{ 'certs' if item == mssql_tls_cert
-          else 'private' }}/{{ item | basename }}
+          {{ __mssql_tls_cert_dest_dir if item == mssql_tls_cert
+          else __mssql_tls_private_key_dest_dir }}/{{ item | basename }}
         owner: mssql
         group: mssql
         mode: "0600"
@@ -635,7 +748,7 @@
       include_tasks: mssql_conf_setting.yml
       vars:
         __mssql_tls_cert_dest: >-
-          /etc/pki/tls/certs/{{ mssql_tls_cert | basename }}
+          {{ __mssql_tls_cert_dest_dir }}/{{ mssql_tls_cert | basename }}
         __mssql_conf_setting: "network tlscert"
         __mssql_conf_setting_value: >-
           {{ __mssql_tls_cert_dest if mssql_tls_enable else 'unset' }}
@@ -644,7 +757,7 @@
       include_tasks: mssql_conf_setting.yml
       vars:
         __mssql_tls_private_key_dest: >-
-          /etc/pki/tls/private/{{ mssql_tls_private_key | basename }}
+          {{ __mssql_tls_private_key_dest_dir }}/{{ mssql_tls_private_key | basename }}
         __mssql_conf_setting: "network tlskey"
         __mssql_conf_setting_value: >-
           {{ __mssql_tls_private_key_dest if mssql_tls_enable else 'unset' }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -684,7 +684,7 @@
 - name: Configure TLS encryption
   when: mssql_tls_enable is not none
   block:
-    - name: Ensure TLS private key directory exists on Debian-family systems
+    - name: Ensure TLS private key directory exists
       file:
         path: "{{ __mssql_tls_private_key_dest_dir }}"
         state: directory
@@ -693,7 +693,6 @@
         mode: "0700"
       when:
         - mssql_tls_enable | bool
-        - ansible_facts["pkg_mgr"] == 'apt'
 
     - name: >-
         Create certificate and private_key files and set mssql_tls_cert

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -285,6 +285,8 @@
         mode: '0644'
       register: __mssql_gpg
       until: __mssql_gpg is success
+      retries: 3
+      delay: 5
 
     - name: Convert Microsoft GPG key to binary keyring format
       command: >-

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MIT
+---
+__mssql_supported_versions:
+  - 2022
+  - 2025
+__mssql_confined_supported: false
+__mssql_tuned_supported: false
+__mssql_gpg_key_dest: /usr/share/keyrings/microsoft-prod.gpg
+__mssql_tls_cert_dest_dir: /etc/ssl/certs
+__mssql_tls_private_key_dest_dir: /etc/ssl/mssql
+__mssql_server_repository: ''
+__mssql_client_repository: ''
+__mssql_client_packages:
+  - "mssql-tools{{ '' if __sqlcmd_ver | int == 17 else __sqlcmd_ver }}"
+  - unixodbc-dev

--- a/vars/Ubuntu_22.yml
+++ b/vars/Ubuntu_22.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+---
+__mssql_server_repository_list_url: >-
+  https://packages.microsoft.com/config/ubuntu/22.04/mssql-server-{{ mssql_version | int }}.list
+__mssql_client_repository_list_url: >-
+  https://packages.microsoft.com/config/ubuntu/22.04/prod.list

--- a/vars/Ubuntu_24.yml
+++ b/vars/Ubuntu_24.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+---
+__mssql_prod_pkg_url: >-
+  https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb
+__mssql_supported_versions:
+  - 2025

--- a/vars/Ubuntu_24.yml
+++ b/vars/Ubuntu_24.yml
@@ -2,5 +2,7 @@
 ---
 __mssql_prod_pkg_url: >-
   https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb
+__mssql_server_repository_list_url: >-
+  https://packages.microsoft.com/config/ubuntu/24.04/mssql-server-{{ mssql_version | int }}.list
 __mssql_supported_versions:
   - 2025

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -33,6 +33,9 @@ __mssql_version_package_mapping:
   - 2017: 14
   - 2019: 15
   - 2022: 16
+  - 2025: 17
+__mssql_tls_cert_dest_dir: /etc/pki/tls/certs
+__mssql_tls_private_key_dest_dir: /etc/pki/tls/private
 __mssql_keytab_path: /var/opt/mssql/secrets/mssql.keytab
 __mssql_conf_path: /var/opt/mssql/mssql.conf
 __mssql_conf_cli: /opt/mssql/bin/mssql-conf


### PR DESCRIPTION
- Add vars/Debian.yml, vars/Ubuntu_22.yml, vars/Ubuntu_24.yml for OS-specific variable overrides (repo URLs, package names, TLS paths)
- Add SQL Server 2025 (ver17) to version package mapping
- Add apt-based GPG key, server repo, and tools repo setup in tasks/main.yml
- Fix hardcoded /etc/pki/tls paths to use configurable vars so TLS works on both RHEL (/etc/pki/tls) and Ubuntu (/etc/ssl)
- Fail fast with clear messages when mssql_ha_configure or mssql_ad_configure is used on Ubuntu (unsupported)
- Update meta/main.yml to declare Ubuntu 22.04 and 24.04 as supported

## Summary by Sourcery

Add Ubuntu 22.04 and 24.04 support for the SQL Server Ansible role, including package repositories, TLS paths, and version mappings, while explicitly limiting unsupported HA and AD features on Ubuntu.

New Features:
- Declare Ubuntu 22.04 and 24.04 as supported platforms for the SQL Server role.
- Introduce Debian/Ubuntu-specific variables for repositories, TLS paths, and client package selection.
- Support SQL Server 2025 through an updated version-to-package mapping.

Bug Fixes:
- Make TLS certificate and key destinations configurable to work across both RHEL-based and Debian-based systems.

Enhancements:
- Add apt-based handling for Microsoft GPG keys and repository configuration on Ubuntu, including upgrade handling and cache updates.
- Prevent unsupported mssql_ha_configure and mssql_ad_configure operations on Ubuntu with explicit fail-fast tasks and clear messages.