### PR TITLE
feat: Parametrize no_log usage in mssql role

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,22 @@ Default: `false`
 
 Type: `bool`
 
+#### mssql_secure_logging
+
+If `true`, suppress potentially sensitive output from tasks that handle
+credentials, secrets, and other sensitive data by setting `no_log: true` on
+those tasks. This prevents passwords, API tokens, SA passwords, and similar
+sensitive information from appearing in Ansible logs and console output.
+
+If you need to debug issues with credential handling or secret management, you
+can temporarily set `mssql_secure_logging: false` to see the full output from
+these tasks. However, be aware that this may expose sensitive information in
+logs, so it should only be used in development or troubleshooting scenarios.
+
+Default: `true`
+
+Type: `bool`
+
 ### Configuring SQL Server as a Confined Application Example Playbook
 
 Run the following playbook against a RHEL 9 system role to configure SQL Server as a confined application.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,3 +86,4 @@ mssql_ad_kerberos_password: >-
 
 mssql_run_selinux_confined: "{{ __mssql_confined_supported | d(false) }}"
 mssql_manage_selinux: false
+mssql_secure_logging: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -190,7 +190,7 @@
 
 - name: Gather package facts
   package_facts:
-  no_log: "{{ __mssql_gather_facts_no_log | d(false) }}"
+  no_log: "{{ ansible_verbosity < 2 }}"
 
 - name: Set fact with the currently installed SQL Server version if any
   set_fact:
@@ -418,7 +418,7 @@
         MSSQL_PID: "{{ mssql_edition }}"
       when: not __mssql_is_setup
       register: __mssql_conf_setup
-      no_log: true
+      no_log: "{{ mssql_secure_logging }}"
       changed_when: true
       # in non-booted mode this tries to start the server, which fails; it
       # still configures things before, so tolerate that
@@ -709,7 +709,7 @@
       ignore_errors: true
       changed_when: false
       register: __mssql_password_query
-      no_log: true
+      no_log: "{{ mssql_secure_logging }}"
       until: __mssql_password_query is success
       when: __mssql_is_booted | bool
 
@@ -724,7 +724,7 @@
 
     - name: Gather package facts
       package_facts:
-      no_log: "{{ __mssql_gather_facts_no_log | d(false) }}"
+      no_log: "{{ ansible_verbosity < 2 }}"
 
     # Setting MSSQL_SA_PASSWORD inline for security because setting it with
     # environment: reveals the value when running playbooks with high verbosity
@@ -737,7 +737,7 @@
           when: (not __mssql_is_booted) or (__mssql_password_query is failed)
           notify: Restart the mssql-server service
           register: __mssql_set_ha_password
-          no_log: true
+          no_log: "{{ mssql_secure_logging }}"
           changed_when: true
       rescue:
         - name: Workaround for expected error on version 2022
@@ -808,7 +808,7 @@
 
     - name: Gather package facts
       package_facts:
-      no_log: "{{ __mssql_gather_facts_no_log | d(false) }}"
+      no_log: "{{ ansible_verbosity < 2 }}"
 
     - name: Change the edition of MSSQL
       block:
@@ -820,7 +820,7 @@
           changed_when: '"The new edition" in __mssql_conf_set_edition.stdout'
           when: not __mssql_is_booted or not __mssql_edition_matches.stdout | bool
           notify: Restart the mssql-server service
-          no_log: true
+          no_log: "{{ mssql_secure_logging }}"
       rescue:
         - name: Workaround for expected error on version 2022
           fail:
@@ -996,7 +996,7 @@
             (__mssql_ad_kinit_user not in __mssql_klist.stdout)
             or
             ("(Expired)" in __mssql_klist_kinit_user.stdout | d())
-          no_log: true
+          no_log: "{{ mssql_secure_logging }}"
           changed_when: true
 
         # Do not fail if account does not exist
@@ -1018,7 +1018,7 @@
             --debug
           register: __mssql_adutil_user_create
           when: not __mssql_adutil_account_exists.stdout | bool
-          no_log: true
+          no_log: "{{ mssql_secure_logging }}"
           changed_when: true
 
         # adutil cli doesn't provide functionality to get info about user
@@ -1094,7 +1094,7 @@
               ~ " (aes128-cts-hmac-sha1-96)"
               in __mssql_keytab_properties.stdout | d()
           notify: Restart the mssql-server service
-          no_log: true
+          no_log: "{{ mssql_secure_logging }}"
           changed_when: true
 
         - name: Add an entry in the keytab for the principal name and password
@@ -1115,7 +1115,7 @@
               ~ ad_integration_realm | upper ~ " (aes128-cts-hmac-sha1-96)"
               in __mssql_keytab_properties.stdout | d()
           notify: Restart the mssql-server service
-          no_log: true
+          no_log: "{{ mssql_secure_logging }}"
           changed_when: true
 
         - name: Ensure correct permissions and ownership on the keytab
@@ -1514,7 +1514,7 @@
             group: root
             mode: "0400"
             force: true
-          no_log: true
+          no_log: "{{ mssql_secure_logging }}"
 
         - name: Run ha_cluster to configure pacemaker
           include_role:

--- a/tasks/sqlcmd_input_content.yml
+++ b/tasks/sqlcmd_input_content.yml
@@ -6,7 +6,7 @@
         {{ __mssql_sqlcmd_login_cmd }} -Q {{ item | quote }} -b
       register: __mssql_sqlcmd_input
       changed_when: '"successfully" in __mssql_sqlcmd_input.stdout'
-      no_log: true
+      no_log: "{{ mssql_secure_logging }}"
       until: __mssql_sqlcmd_input is success
 
   always:

--- a/tasks/sqlcmd_input_file.yml
+++ b/tasks/sqlcmd_input_file.yml
@@ -30,7 +30,7 @@
         {{ __mssql_sqlcmd_login_cmd }} -i {{ __mssql_sql_tempfile.path }} -b
       register: __mssql_sqlcmd_input
       changed_when: '"successfully" in __mssql_sqlcmd_input.stdout'
-      no_log: true
+      no_log: "{{ mssql_secure_logging }}"
       until: __mssql_sqlcmd_input is success
   always:
     # Role prints the output if the input succeeds, otherwise Ansible prints the

--- a/tasks/verify_password.yml
+++ b/tasks/verify_password.yml
@@ -36,4 +36,4 @@
       {{ __ipaddress_arg }}{{ ',' if __tcpport
       else '' }}{{ __tcpport if __tcpport else '' }}
       -U sa -P {{ mssql_password | quote }}
-  no_log: true
+  no_log: "{{ mssql_secure_logging }}"


### PR DESCRIPTION
Feature: Introduce the `mssql_secure_logging` variable that defaults to `true` and using verbosity-based logging for facts modules.

Reason: Currently, all sensitive tasks use hard-coded no_log: true, which makes debugging difficult. Users cannot see credential-related output even when troubleshooting authentication or secret management issues. Additionally, package_facts produces verbose output that clutters logs during normal operation.

Result:
  - Tasks handling credentials, secrets, and sensitive data now use no_log: "{{ mssql_secure_logging }}", allowing users to set mssql_secure_logging: false for debugging while maintaining secure defaults (true)
  - package_facts now uses no_log: "{{ ansible_verbosity < 2 }}", hiding verbose output unless -vv or higher verbosity is specified
  - New variable mssql_secure_logging documented in README.md with guidance on when to disable it
  - Users can now debug credential and secret issues without modifying role code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Parametrize secure logging behavior in the mssql role and adjust fact gathering verbosity to improve debuggability while keeping safe defaults.

New Features:
- Introduce the mssql_secure_logging boolean variable to control no_log usage for sensitive mssql tasks.

Enhancements:
- Apply mssql_secure_logging to existing sensitive tasks so their output can be selectively logged for troubleshooting.
- Change package_facts tasks to hide output by default and only show it at higher Ansible verbosity levels.
- Document mssql_secure_logging behavior and defaults in the role README.