### PR TITLE
fix: Use verbosity level 3 for no_log

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -190,7 +190,7 @@
 
 - name: Gather package facts
   package_facts:
-  no_log: "{{ ansible_verbosity < 2 }}"
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: Set fact with the currently installed SQL Server version if any
   set_fact:
@@ -724,7 +724,7 @@
 
     - name: Gather package facts
       package_facts:
-      no_log: "{{ ansible_verbosity < 2 }}"
+      no_log: "{{ ansible_verbosity < 3 }}"
 
     # Setting MSSQL_SA_PASSWORD inline for security because setting it with
     # environment: reveals the value when running playbooks with high verbosity
@@ -808,7 +808,7 @@
 
     - name: Gather package facts
       package_facts:
-      no_log: "{{ ansible_verbosity < 2 }}"
+      no_log: "{{ ansible_verbosity < 3 }}"
 
     - name: Change the edition of MSSQL
       block:


### PR DESCRIPTION
Use `ansible_verbosity < 3` instead of `< 2` to show output with `-vvv` or higher.

## Summary by Sourcery

Bug Fixes:
- Correct logging condition so package fact tasks remain suppressed until verbosity level 3 or higher.